### PR TITLE
feat: add Env factory for typed private/public env validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,16 @@
       "import": "./dist/shared/utils/functional/index.js",
       "require": "./dist/shared/utils/functional/index.js"
     },
+    "./utils/env": {
+      "types": "./dist/shared/utils/env.d.ts",
+      "import": "./dist/shared/utils/env.js",
+      "require": "./dist/shared/utils/env.js"
+    },
+    "./server/env": {
+      "types": "./dist/shared/server/env.d.ts",
+      "import": "./dist/shared/server/env.js",
+      "require": "./dist/shared/server/env.js"
+    },
     "./server/form-handler": {
       "types": "./dist/shared/server/form-handler.d.ts",
       "import": "./dist/shared/server/form-handler.js",

--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -36,7 +36,8 @@ function makePrivate<L extends ZodRawShape, S extends ZodRawShape>(
       const sharedValues = await Promise.all(
         sharedKeys.map((key) => {
           const val = platformEnv![key];
-          if (val && typeof val !== 'string' && 'get' in val) return val.get();
+          if (val && typeof val === 'object' && 'get' in val && typeof val.get === 'function')
+            return val.get();
           return Promise.resolve(typeof val === 'string' ? val : undefined);
         })
       );
@@ -52,8 +53,9 @@ function makePrivate<L extends ZodRawShape, S extends ZodRawShape>(
 
     const result = localSchema.merge(sharedSchema).safeParse(raw);
     if (!result.success) {
-      const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
-      throw new Error(`Missing required environment variables: ${missing}`);
+      throw new Error(
+        `Environment validation failed: ${result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`
+      );
     }
     _cached = result.data as Result;
     return _cached;

--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -1,9 +1,10 @@
+import type { z, ZodObject, ZodRawShape } from 'zod/v4';
+
 import { getRequestEvent } from '$app/server';
 import { env as dynamicEnv } from '$env/dynamic/private';
-import { type ZodObject, type ZodRawShape, z } from 'zod/v4';
 
-type SecretBinding = { get(): Promise<string | null> };
-type PlatformEnv = Record<string, string | SecretBinding | undefined>;
+type PlatformEnv = Record<string, SecretBinding | string | undefined>;
+type SecretBinding = { get(): Promise<null | string> };
 
 function makePrivate<L extends ZodRawShape, S extends ZodRawShape>(
   localSchema: ZodObject<L>,

--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -1,0 +1,61 @@
+import { getRequestEvent } from '$app/server';
+import { env as dynamicEnv } from '$env/dynamic/private';
+import { type ZodObject, type ZodRawShape, z } from 'zod';
+
+type SecretBinding = { get(): Promise<string | null> };
+type PlatformEnv = Record<string, string | SecretBinding | undefined>;
+
+function makePrivate<L extends ZodRawShape, S extends ZodRawShape>(
+	localSchema: ZodObject<L>,
+	sharedSchema: ZodObject<S>
+) {
+	type Result = z.infer<ZodObject<L>> & z.infer<ZodObject<S>>;
+	let _cached: Result | undefined;
+
+	return async (): Promise<Result> => {
+		if (_cached) return _cached;
+
+		const localKeys = Object.keys(localSchema.shape);
+		const sharedKeys = Object.keys(sharedSchema.shape);
+		const raw: Record<string, string | undefined> = {};
+
+		let platformEnv: PlatformEnv | undefined;
+		try {
+			platformEnv = getRequestEvent().platform?.env as PlatformEnv | undefined;
+		} catch {
+			// Outside request context (build, tests) — fall through to dynamicEnv
+		}
+
+		if (platformEnv) {
+			for (const key of localKeys) {
+				const val = platformEnv[key];
+				raw[key] = typeof val === 'string' ? val : undefined;
+			}
+			const sharedValues = await Promise.all(
+				sharedKeys.map((key) => {
+					const val = platformEnv![key];
+					if (val && typeof val !== 'string' && 'get' in val) return val.get();
+					return Promise.resolve(typeof val === 'string' ? val : undefined);
+				})
+			);
+			sharedKeys.forEach((key, i) => {
+				raw[key] = sharedValues[i] ?? undefined;
+			});
+		} else {
+			const fallback = dynamicEnv as Record<string, string | undefined>;
+			for (const key of [...localKeys, ...sharedKeys]) {
+				raw[key] = fallback[key];
+			}
+		}
+
+		const result = localSchema.merge(sharedSchema).safeParse(raw);
+		if (!result.success) {
+			const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+			throw new Error(`Missing required environment variables: ${missing}`);
+		}
+		_cached = result.data as Result;
+		return _cached;
+	};
+}
+
+export const Env = { makePrivate };

--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -1,61 +1,62 @@
 import { getRequestEvent } from '$app/server';
 import { env as dynamicEnv } from '$env/dynamic/private';
-import { type ZodObject, type ZodRawShape, z } from 'zod';
+import { type ZodObject, type ZodRawShape, z } from 'zod/v4';
 
 type SecretBinding = { get(): Promise<string | null> };
 type PlatformEnv = Record<string, string | SecretBinding | undefined>;
 
 function makePrivate<L extends ZodRawShape, S extends ZodRawShape>(
-	localSchema: ZodObject<L>,
-	sharedSchema: ZodObject<S>
+  localSchema: ZodObject<L>,
+  sharedSchema: ZodObject<S>
 ) {
-	type Result = z.infer<ZodObject<L>> & z.infer<ZodObject<S>>;
-	let _cached: Result | undefined;
+  type Result = z.infer<ZodObject<L>> & z.infer<ZodObject<S>>;
+  let _cached: Result | undefined;
 
-	return async (): Promise<Result> => {
-		if (_cached) return _cached;
+  return async (): Promise<Result> => {
+    if (_cached) return _cached;
 
-		const localKeys = Object.keys(localSchema.shape);
-		const sharedKeys = Object.keys(sharedSchema.shape);
-		const raw: Record<string, string | undefined> = {};
+    const localKeys = Object.keys(localSchema.shape);
+    const sharedKeys = Object.keys(sharedSchema.shape);
+    const raw: Record<string, string | undefined> = {};
 
-		let platformEnv: PlatformEnv | undefined;
-		try {
-			platformEnv = getRequestEvent().platform?.env as PlatformEnv | undefined;
-		} catch {
-			// Outside request context (build, tests) — fall through to dynamicEnv
-		}
+    let platformEnv: PlatformEnv | undefined;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      platformEnv = (getRequestEvent().platform as any)?.env as PlatformEnv | undefined;
+    } catch {
+      // Outside request context (build, tests) — fall through to dynamicEnv
+    }
 
-		if (platformEnv) {
-			for (const key of localKeys) {
-				const val = platformEnv[key];
-				raw[key] = typeof val === 'string' ? val : undefined;
-			}
-			const sharedValues = await Promise.all(
-				sharedKeys.map((key) => {
-					const val = platformEnv![key];
-					if (val && typeof val !== 'string' && 'get' in val) return val.get();
-					return Promise.resolve(typeof val === 'string' ? val : undefined);
-				})
-			);
-			sharedKeys.forEach((key, i) => {
-				raw[key] = sharedValues[i] ?? undefined;
-			});
-		} else {
-			const fallback = dynamicEnv as Record<string, string | undefined>;
-			for (const key of [...localKeys, ...sharedKeys]) {
-				raw[key] = fallback[key];
-			}
-		}
+    if (platformEnv) {
+      for (const key of localKeys) {
+        const val = platformEnv[key];
+        raw[key] = typeof val === 'string' ? val : undefined;
+      }
+      const sharedValues = await Promise.all(
+        sharedKeys.map((key) => {
+          const val = platformEnv![key];
+          if (val && typeof val !== 'string' && 'get' in val) return val.get();
+          return Promise.resolve(typeof val === 'string' ? val : undefined);
+        })
+      );
+      for (let i = 0; i < sharedKeys.length; i++) {
+        raw[sharedKeys[i]] = sharedValues[i] ?? undefined;
+      }
+    } else {
+      const fallback = dynamicEnv as Record<string, string | undefined>;
+      for (const key of [...localKeys, ...sharedKeys]) {
+        raw[key] = fallback[key];
+      }
+    }
 
-		const result = localSchema.merge(sharedSchema).safeParse(raw);
-		if (!result.success) {
-			const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
-			throw new Error(`Missing required environment variables: ${missing}`);
-		}
-		_cached = result.data as Result;
-		return _cached;
-	};
+    const result = localSchema.merge(sharedSchema).safeParse(raw);
+    if (!result.success) {
+      const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+      throw new Error(`Missing required environment variables: ${missing}`);
+    }
+    _cached = result.data as Result;
+    return _cached;
+  };
 }
 
 export const Env = { makePrivate };

--- a/src/lib/shared/utils/env.ts
+++ b/src/lib/shared/utils/env.ts
@@ -11,8 +11,9 @@ function makePublic<S extends ZodRawShape>(schema: ZodObject<S>) {
 
     const result = schema.safeParse(dynamicEnv);
     if (!result.success) {
-      const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
-      throw new Error(`Missing required environment variables: ${missing}`);
+      throw new Error(
+        `Environment validation failed: ${result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`
+      );
     }
     _cached = result.data;
     return _cached;

--- a/src/lib/shared/utils/env.ts
+++ b/src/lib/shared/utils/env.ts
@@ -1,21 +1,21 @@
 import { env as dynamicEnv } from '$env/dynamic/public';
-import { type ZodObject, type ZodRawShape } from 'zod';
+import { type ZodObject, type ZodRawShape } from 'zod/v4';
 
 function makePublic<S extends ZodRawShape>(schema: ZodObject<S>) {
-	type Result = ReturnType<typeof schema.parse>;
-	let _cached: Result | undefined;
+  type Result = ReturnType<typeof schema.parse>;
+  let _cached: Result | undefined;
 
-	return (): Result => {
-		if (_cached) return _cached;
+  return (): Result => {
+    if (_cached) return _cached;
 
-		const result = schema.safeParse(dynamicEnv);
-		if (!result.success) {
-			const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
-			throw new Error(`Missing required environment variables: ${missing}`);
-		}
-		_cached = result.data;
-		return _cached;
-	};
+    const result = schema.safeParse(dynamicEnv);
+    if (!result.success) {
+      const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+      throw new Error(`Missing required environment variables: ${missing}`);
+    }
+    _cached = result.data;
+    return _cached;
+  };
 }
 
 export const Env = { makePublic };

--- a/src/lib/shared/utils/env.ts
+++ b/src/lib/shared/utils/env.ts
@@ -1,0 +1,21 @@
+import { env as dynamicEnv } from '$env/dynamic/public';
+import { type ZodObject, type ZodRawShape } from 'zod';
+
+function makePublic<S extends ZodRawShape>(schema: ZodObject<S>) {
+	type Result = ReturnType<typeof schema.parse>;
+	let _cached: Result | undefined;
+
+	return (): Result => {
+		if (_cached) return _cached;
+
+		const result = schema.safeParse(dynamicEnv);
+		if (!result.success) {
+			const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+			throw new Error(`Missing required environment variables: ${missing}`);
+		}
+		_cached = result.data;
+		return _cached;
+	};
+}
+
+export const Env = { makePublic };

--- a/src/lib/shared/utils/env.ts
+++ b/src/lib/shared/utils/env.ts
@@ -1,5 +1,6 @@
+import type { ZodObject, ZodRawShape } from 'zod/v4';
+
 import { env as dynamicEnv } from '$env/dynamic/public';
-import { type ZodObject, type ZodRawShape } from 'zod/v4';
 
 function makePublic<S extends ZodRawShape>(schema: ZodObject<S>) {
   type Result = ReturnType<typeof schema.parse>;


### PR DESCRIPTION
## Summary
- `Env.makePrivate(localSchema, sharedSchema)` — lazy async getter for server env; resolves CF Secret Store via `.get()`, worker bindings directly, falls back to `$env/dynamic/private` in local dev
- `Env.makePublic(schema)` — lazy sync getter from `$env/dynamic/public`
- Added `./server/env` and `./utils/env` package exports

## Usage
```ts
// $lib/server/env.ts
import { Env } from '@webamoki/web-svelte/server/env';
export const privateEnv = Env.makePrivate(localSchema, sharedSchema);

// $lib/env.ts
import { Env } from '@webamoki/web-svelte/utils/env';
export const publicEnv = Env.makePublic(schema);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)