### PR TITLE
fix: fall back to dynamicEnv when secrets store .get() fails locally

### DIFF
--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -25,10 +25,16 @@ function makePrivate<S extends ZodRawShape>(schema: ZodObject<S>) {
 
     if (platformEnv) {
       const values = await Promise.all(
-        keys.map((key) => {
+        keys.map(async (key) => {
           const val = platformEnv![key];
-          if (val && typeof val === 'object' && 'get' in val && typeof val.get === 'function')
-            return val.get();
+          if (val && typeof val === 'object' && 'get' in val && typeof val.get === 'function') {
+            try {
+              return await val.get();
+            } catch {
+              // Secrets Store not seeded locally (Miniflare) — fall back to .env
+              return (dynamicEnv as Record<string, string | undefined>)[key];
+            }
+          }
           return Promise.resolve(typeof val === 'string' ? val : undefined);
         })
       );

--- a/src/lib/shared/server/env.ts
+++ b/src/lib/shared/server/env.ts
@@ -25,17 +25,12 @@ function makePrivate<S extends ZodRawShape>(schema: ZodObject<S>) {
 
     if (platformEnv) {
       const values = await Promise.all(
-        keys.map(async (key) => {
+        keys.map((key) => {
           const val = platformEnv![key];
           if (val && typeof val === 'object' && 'get' in val && typeof val.get === 'function') {
-            try {
-              return await val.get();
-            } catch {
-              // Secrets Store not seeded locally (Miniflare) — fall back to .env
-              return (dynamicEnv as Record<string, string | undefined>)[key];
-            }
+            return val.get().catch(() => (dynamicEnv as Record<string, string | undefined>)[key]);
           }
-          return Promise.resolve(typeof val === 'string' ? val : undefined);
+          return typeof val === 'string' ? val : undefined;
         })
       );
       for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
Miniflare creates Secrets Store mock bindings that throw "Secret not found" in local dev since values aren't seeded. Catch the error and fall back to $env/dynamic/private so wrangler dev works without manual store seeding.