### PR TITLE
fix: move svelte-sonner to peerDependencies to prevent duplicate inst…

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@tailwindcss/forms": "catalog:",
     "@tailwindcss/typography": "catalog:",
     "svelte": "catalog:",
+    "svelte-sonner": "catalog:",
     "sveltekit-superforms": "catalog:",
     "tailwindcss": "catalog:",
     "zod": "catalog:"
@@ -144,6 +145,7 @@
     "svelte": "catalog:",
     "svelte-check": "^4.4.6",
     "svelte-eslint-parser": "^1.6.0",
+    "svelte-sonner": "catalog:",
     "sveltekit-superforms": "catalog:",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
@@ -175,8 +177,7 @@
     "formsnap": "^2.0.1",
     "ramda": "^0.32.0",
     "sorted-array-functions": "^1.3.0",
-    "svelte-awesome-color-picker": "^4.1.2",
-    "svelte-sonner": "^1.1.0"
+    "svelte-awesome-color-picker": "^4.1.2"
   },
   "engines": {
     "node": "^24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     svelte:
       specifier: ^5.55.4
       version: 5.55.4
+    svelte-sonner:
+      specifier: ^1.1.0
+      version: 1.1.1
     sveltekit-superforms:
       specifier: ^2.30.1
       version: 2.30.1
@@ -53,9 +56,6 @@ importers:
       svelte-awesome-color-picker:
         specifier: ^4.1.2
         version: 4.1.2(svelte@5.55.4(@typescript-eslint/types@8.58.2))
-      svelte-sonner:
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
     devDependencies:
       '@anolilab/semantic-release-pnpm':
         specifier: ^8.1.1
@@ -159,6 +159,9 @@ importers:
       svelte-eslint-parser:
         specifier: ^1.6.0
         version: 1.6.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+      svelte-sonner:
+        specifier: 'catalog:'
+        version: 1.1.1(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       sveltekit-superforms:
         specifier: 'catalog:'
         version: 2.30.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)))(@types/json-schema@7.0.15)(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)
@@ -2707,8 +2710,8 @@ packages:
       svelte:
         optional: true
 
-  svelte-sonner@1.1.0:
-    resolution: {integrity: sha512-3lYM6ZIqWe+p9vwwWHGWP/ZdvHiUtzURsud2quIxivrX4rvpXh6i+geBGn0m3JS6KwW6W8VgbOl3xQMcDuh6gg==}
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -5592,7 +5595,7 @@ snapshots:
     optionalDependencies:
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
 
-  svelte-sonner@1.1.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)):
+  svelte-sonner@1.1.1(svelte@5.55.4(@typescript-eslint/types@8.58.2)):
     dependencies:
       runed: 0.28.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   '@tailwindcss/forms': ^0.5.11
   '@tailwindcss/typography': ^0.5.19
   svelte: ^5.55.4
+  svelte-sonner: ^1.1.0
   sveltekit-superforms: ^2.30.1
   tailwindcss: ^4.2.2
   zod: ^4.3.6


### PR DESCRIPTION
…ances

Toast notifications were not displaying because svelte-sonner was bundled as a dependency, creating separate instances in the library and consuming applications. Moving it to peerDependencies ensures a single shared instance, allowing toasts to work correctly.