### PR TITLE
fix: auto-set multipart enctype when form has file inputs

### DIFF
--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -48,18 +48,16 @@
   // Force enctype after the remote-form spread applies (which sets its own enctype).
   // Defaults to multipart when the form contains file inputs, so consumers can't forget it.
   function applyEnctype(node: HTMLFormElement) {
-    $effect(() => {
-      const wanted =
-        enctype ?? (node.querySelector('input[type="file"]') ? 'multipart/form-data' : undefined);
-      if (wanted) node.setAttribute('enctype', wanted);
-    });
+    const wanted =
+      enctype ?? (node.querySelector('input[type="file"]') ? 'multipart/form-data' : undefined);
+    if (wanted) node.setAttribute('enctype', wanted);
   }
 </script>
 
 <form
   class={className}
-  {@attach applyEnctype}
   oninput={() => remote.validate()}
+  use:applyEnctype
   {...remote.preflight(schema).enhance(async ({ form: formElement, submit }) => {
     try {
       const submitted = await submit();

--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -44,11 +44,21 @@
   if (defaults !== undefined) {
     remote.fields.set(defaults);
   }
+
+  // Force enctype after the remote-form spread applies (which sets its own enctype).
+  // Defaults to multipart when the form contains file inputs, so consumers can't forget it.
+  function applyEnctype(node: HTMLFormElement) {
+    $effect(() => {
+      const wanted =
+        enctype ?? (node.querySelector('input[type="file"]') ? 'multipart/form-data' : undefined);
+      if (wanted) node.setAttribute('enctype', wanted);
+    });
+  }
 </script>
 
 <form
   class={className}
-  {enctype}
+  {@attach applyEnctype}
   oninput={() => remote.validate()}
   {...remote.preflight(schema).enhance(async ({ form: formElement, submit }) => {
     try {


### PR DESCRIPTION
## Summary
- `Form` now auto-detects `<input type="file">` and applies `enctype="multipart/form-data"` after the remote-form spread, so file uploads work without consumers manually setting `enctype`.
- Fixes the SvelteKit runtime warning: *"Your form contains `<input type="file">` fields, but is missing the necessary `enctype="multipart/form-data"` attribute."*
- The explicit `enctype` prop still works as an override escape hatch.

## Why an attachment (not schema introspection)
`schema` is typed as `StandardSchemaV1`, which exposes no field/shape introspection — detecting file fields would require brittle Zod-internal access that breaks on wrapped/nested types (`nullable`, arrays, `z.instanceof(File).refine(...)`). A DOM query is framework-agnostic, runs post-render (so it overrides the spread's `enctype`), and catches files regardless of schema shape.

## Test plan
- [ ] `pnpm check` passes (fmt, lint, svelte-check, tests) — verified locally
- [ ] FileField demos on `/fields` submit without the enctype warning (button + dropzone variants)
- [ ] A non-file form still submits normally (no spurious enctype)

🤖 Generated with [Claude Code](https://claude.com/claude-code)