### PR TITLE
fix: skip hidden inputs with unset values to prevent render error

### DIFF
--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -45,6 +45,12 @@
     remote.fields.set(defaults);
   }
 
+  // Only render hidden inputs whose value is set — `as('hidden', value)` throws on
+  // null/undefined. Derived so value changes on `hidden` propagate to the inputs.
+  const hiddenEntries = $derived(
+    hidden ? Object.entries(hidden).filter(([, value]) => value != null) : []
+  );
+
   // Force enctype after the remote-form spread applies (which sets its own enctype).
   // Defaults to multipart when the form contains file inputs, so consumers can't forget it.
   function applyEnctype(node: HTMLFormElement) {
@@ -88,10 +94,8 @@
     }
   })}
 >
-  {#if hidden}
-    {#each Object.entries(hidden) as [name, value] (name)}
-      <input {...remote.fields[name].as('hidden', value)} />
-    {/each}
-  {/if}
+  {#each hiddenEntries as [name, value] (name)}
+    <input {...remote.fields[name].as('hidden', value)} />
+  {/each}
   {@render children?.()}
 </form>

--- a/src/routes/fields/+page.svelte
+++ b/src/routes/fields/+page.svelte
@@ -34,6 +34,7 @@
     emailForm,
     emailNullableForm,
     fileForm,
+    hiddenForm,
     messageForm,
     numberForm,
     numberNullableForm,
@@ -56,6 +57,7 @@
     EmailNullableSchema,
     EmailSchema,
     FileSchema,
+    HiddenSchema,
     MessageSchema,
     NumberNullableSchema,
     NumberSchema,
@@ -70,6 +72,9 @@
     TextSchema,
     TimeSchema
   } from './schemas.js';
+
+  let hiddenToken = $state<string | undefined>('abc123');
+  let hiddenCount = $state<string | undefined>('1');
 </script>
 
 <Sidebar.Provider>
@@ -82,7 +87,7 @@
         <Sidebar.GroupLabel>New (Remote Forms)</Sidebar.GroupLabel>
         <Sidebar.GroupContent>
           <Sidebar.Menu>
-            {#each [['textfield', 'TextField'], ['emailfield', 'EmailField'], ['passwordfield', 'PasswordField'], ['numberfield', 'NumberField'], ['datefield', 'DateField'], ['daterangefield', 'DateRangeField'], ['timefield', 'TimeField'], ['checkboxfield', 'CheckboxField'], ['hexcolorfield', 'HexColorField'], ['messagefield', 'MessageField'], ['pinfield', 'PinField'], ['selectfield', 'SelectField'], ['filefield', 'FileField'], ['form', 'Form']] as [anchor, label] (anchor)}
+            {#each [['textfield', 'TextField'], ['emailfield', 'EmailField'], ['passwordfield', 'PasswordField'], ['numberfield', 'NumberField'], ['datefield', 'DateField'], ['daterangefield', 'DateRangeField'], ['timefield', 'TimeField'], ['checkboxfield', 'CheckboxField'], ['hexcolorfield', 'HexColorField'], ['messagefield', 'MessageField'], ['pinfield', 'PinField'], ['selectfield', 'SelectField'], ['filefield', 'FileField'], ['hidden', 'Hidden inputs'], ['form', 'Form']] as [anchor, label] (anchor)}
               <Sidebar.MenuItem>
                 <Sidebar.MenuButton>
                   {#snippet child({ props })}
@@ -535,6 +540,57 @@
         <CodeBlock slot="code">
           {`<FileField name="file" form={remoteForm}>Upload</FileField>
 <FileField name="file" form={remoteForm} variant="dropzone">Upload</FileField>`}
+        </CodeBlock>
+      </Container>
+
+      <Container
+        description="Hidden inputs driven by external state; cleared values are skipped (no render error) and changes propagate reactively"
+        title="Hidden inputs"
+      >
+        <Preview slot="preview">
+          <div class="flex gap-6">
+            <div class="flex flex-col gap-2">
+              <button
+                class="btn ghost"
+                onclick={() => (hiddenToken = crypto.randomUUID().slice(0, 8))}
+                type="button"
+              >
+                Set random token
+              </button>
+              <button class="btn ghost" onclick={() => (hiddenToken = undefined)} type="button">
+                Clear token
+              </button>
+              <button
+                class="btn ghost"
+                onclick={() => (hiddenCount = String(Number(hiddenCount ?? '0') + 1))}
+                type="button"
+              >
+                Increment count
+              </button>
+              <button class="btn ghost" onclick={() => (hiddenCount = undefined)} type="button">
+                Clear count
+              </button>
+              <p class="text-xs text-gray-600">
+                token: {hiddenToken ?? '(none)'}<br />count: {hiddenCount ?? '(none)'}
+              </p>
+            </div>
+            <Form
+              class="flex flex-1 flex-col gap-4"
+              form={hiddenForm}
+              hidden={{ count: hiddenCount, token: hiddenToken }}
+              onSuccess={(data) => console.log('Submitted:', data)}
+              schema={HiddenSchema}
+            >
+              <TextField name="label" form={hiddenForm}>Label</TextField>
+              <Button form={hiddenForm}>Submit</Button>
+            </Form>
+          </div>
+        </Preview>
+        <CodeBlock slot="code">
+          {`<Form form={hiddenForm} hidden={{ token, count }} schema={HiddenSchema}>
+  <TextField name="label" form={hiddenForm}>Label</TextField>
+  <Button form={hiddenForm}>Submit</Button>
+</Form>`}
         </CodeBlock>
       </Container>
 

--- a/src/routes/fields/action.remote.ts
+++ b/src/routes/fields/action.remote.ts
@@ -10,6 +10,7 @@ import {
   EmailNullableSchema,
   EmailSchema,
   FileSchema,
+  HiddenSchema,
   MessageSchema,
   NumberNullableSchema,
   NumberSchema,
@@ -83,6 +84,8 @@ export const dateRangeForm = form(DateRangeSchema, async (data) => {
 export const fileForm = form(FileSchema, async (data) =>
   ok({ name: data.file.name, size: data.file.size })
 );
+
+export const hiddenForm = form(HiddenSchema, async (data) => ok(data));
 
 export const showcaseForm = form(ShowcaseSchema, async (data) => ok(data));
 

--- a/src/routes/fields/schemas.ts
+++ b/src/routes/fields/schemas.ts
@@ -33,6 +33,11 @@ export const ColorSchema = z.object({ color: formHexColor });
 export const MessageSchema = z.object({ message: formText });
 export const PinSchema = z.object({ pin: formPin() });
 export const SelectSchema = z.object({ select: formSelect(SELECT_OPTIONS) });
+export const HiddenSchema = z.object({
+  count: formNumber,
+  label: formText,
+  token: formText
+});
 
 export const TextNullableSchema = z.object({ text: nullable(formText) });
 export const EmailNullableSchema = z.object({ email: nullable(formEmail) });


### PR DESCRIPTION
## Summary
- `Form`'s `hidden` prop crashed with a 500 (`hidden inputs must have a value`) when any value was null/undefined, because `field.as('hidden', value)` throws on unset values.
- Now renders only entries with a set value via a `$derived` filtered list — cleared values are skipped, and value changes on the `hidden` prop propagate reactively to the inputs.
- Added a **Hidden inputs** showcase on `/fields` with side buttons that set/clear `token` and `count`, demonstrating skip-on-empty + reactive updates.

## Test plan
- [ ] `pnpm check` passes (fmt, lint, svelte-check, tests) — verified locally (0 errors, 165 tests)
- [ ] `/fields#hidden`: clear a value → no 500, input disappears
- [ ] Set/increment a value → hidden input re-renders with new value
- [ ] Submit with all values set succeeds; submit with a cleared required value fails validation (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)