### PR TITLE
feat: form-optional fields, SliderField, switch ON/OFF variant

### DIFF
--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -1,31 +1,59 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import UiInput from '$lib/shared/components/ui/Input.svelte';
 
+  import { createFormView, createLocalTextView, type FieldView } from './field-view.svelte.js';
   import FieldLabel from './FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: string): { [k: string]: unknown; name: string };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-  };
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    /** When omitted the field is standalone — controlled via `bind:value`. */
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     name: keyof Input & string;
+    /** Standalone only — fired on the native `change` event. */
+    onChange?: (value: T) => void;
+    /** Standalone only — fired on every keystroke. */
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
+    /** Standalone only — optional per-field validation. */
+    schema?: ZodType;
     type: string;
+    /** Standalone only — bound value when no `form` is provided. */
+    value?: T;
   }
 
-  let { children, form, icon, name, optional, placeholder, type }: Props = $props();
+  let {
+    children,
+    form,
+    icon,
+    name,
+    onChange,
+    onInput,
+    optional,
+    placeholder,
+    schema,
+    type,
+    value = $bindable()
+  }: Props = $props();
+
+  // `form`, `name` and `type` are fixed for a field instance; reading them once is intended.
+  // `as()` is reached only via the `form` branch, so the standalone path never calls it.
   // svelte-ignore state_referenced_locally
-  const field = (form.fields as Record<string, LooseField>)[name];
-  // svelte-ignore state_referenced_locally
-  const attrs = field.as(type);
+  const view: FieldView = form
+    ? createFormView(form, name, type)
+    : createLocalTextView<T>({
+        get: () => value as T,
+        name,
+        onChange,
+        onInput,
+        schema,
+        write: (v) => (value = v)
+      });
 
   const required = $derived(!optional);
 
@@ -40,10 +68,17 @@
 
 <div class="form-field">
   {#if children}
-    <FieldLabel for={attrs.name} {required}>{@render children()}</FieldLabel>
+    <FieldLabel for={view.attrs.name} {required}>{@render children()}</FieldLabel>
   {/if}
-  <UiInput id={attrs.name} {icon} placeholder={displayPlaceholder} {required} {...attrs} />
-  {#each field.issues() ?? [] as issue, i (i)}
+  <UiInput
+    id={view.attrs.name}
+    {icon}
+    placeholder={displayPlaceholder}
+    {required}
+    {type}
+    {...view.attrs}
+  />
+  {#each view.issues() as issue, i (i)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/field-view.svelte.ts
+++ b/src/lib/shared/components/form/field-view.svelte.ts
@@ -1,0 +1,190 @@
+import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
+import type { ZodType } from 'zod/v4';
+
+/** Normalised validation issue shape consumed by every field template. */
+export type FieldIssue = { message: string; path: Array<number | string> };
+
+/**
+ * The surface every field template consumes. Produced either from a `RemoteForm`
+ * field (`createFormView`) or from local `$bindable` state (`createLocal*View`).
+ * `attrs` is spread onto the underlying input/select/checkbox.
+ */
+export type FieldView = {
+  readonly attrs: Record<string, unknown> & { name: string };
+  issues: () => FieldIssue[];
+  set: (value: unknown) => void;
+};
+
+type LooseFormField = {
+  as(type: string, ...args: unknown[]): Record<string, unknown> & { name: string };
+  issues(): FieldIssue[] | undefined;
+  set(input: unknown): unknown;
+};
+
+/**
+ * Wrap a `RemoteForm` field. `as()` is called ONLY here, so the standalone path
+ * never touches it. Must be called during component init (uses `$derived`).
+ */
+export function createFormView<Input extends RemoteFormInput>(
+  form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>,
+  name: string,
+  type: string,
+  asArgs: unknown[] = []
+): FieldView {
+  const field = $derived((form.fields as Record<string, LooseFormField>)[name]);
+  const attrs = $derived(field.as(type, ...asArgs));
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => field.issues() ?? [],
+    set: (value) => field.set(value)
+  };
+}
+
+function schemaIssues(schema: undefined | ZodType, value: unknown): FieldIssue[] {
+  if (!schema) return [];
+  const result = schema.safeParse(value);
+  if (result.success) return [];
+  return result.error.issues.map((issue) => ({
+    message: issue.message,
+    path: issue.path as Array<number | string>
+  }));
+}
+
+type LocalOpts<T> = {
+  /** Reads the parent `$bindable` value. */
+  get: () => T;
+  name: string;
+  onChange?: (value: T) => void;
+  onInput?: (value: T) => void;
+  schema?: ZodType;
+  /** Writes the parent `$bindable` value. */
+  write: (value: T) => void;
+};
+
+/**
+ * Text-like standalone view (text/number/date/time/email/password/etc.).
+ * Builds its own `oninput`/`onchange` since `as()` does not provide them.
+ */
+export function createLocalTextView<T>(opts: LocalOpts<T>): FieldView {
+  const issues = $derived.by(() => schemaIssues(opts.schema, opts.get()));
+  const attrs = $derived({
+    'aria-invalid': issues.length > 0 ? ('true' as const) : undefined,
+    name: opts.name,
+    onchange: (event: Event) => {
+      const value = (event.currentTarget as HTMLInputElement).value as unknown as T;
+      opts.onChange?.(value);
+    },
+    oninput: (event: Event) => {
+      const value = (event.currentTarget as HTMLInputElement).value as unknown as T;
+      opts.write(value);
+      opts.onInput?.(value);
+    },
+    value: (opts.get() ?? '') as unknown
+  });
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => issues,
+    set: (value) => {
+      opts.write(value as T);
+      opts.onInput?.(value as T);
+      opts.onChange?.(value as T);
+    }
+  };
+}
+
+/** Checkbox/switch standalone view — `checked` instead of `value`, boolean state. */
+export function createLocalCheckboxView(opts: LocalOpts<boolean>): FieldView {
+  const issues = $derived.by(() => schemaIssues(opts.schema, opts.get()));
+  const attrs = $derived({
+    'aria-invalid': issues.length > 0 ? ('true' as const) : undefined,
+    checked: opts.get() === true,
+    name: opts.name,
+    type: 'checkbox' as const
+  });
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => issues,
+    set: (value) => {
+      const next = value === true;
+      opts.write(next);
+      opts.onInput?.(next);
+      opts.onChange?.(next);
+    }
+  };
+}
+
+/**
+ * File standalone view — the native file input stays uncontrolled, so `set` is a
+ * no-op; `attrs` only carries the name + validity, and `issues()` validates the
+ * currently-selected files against the optional schema.
+ */
+export function createLocalFileView(opts: {
+  get: () => File[];
+  name: string;
+  schema?: ZodType;
+}): FieldView {
+  const issues = $derived.by(() => schemaIssues(opts.schema, opts.get()));
+  const attrs = $derived({
+    'aria-invalid': issues.length > 0 ? ('true' as const) : undefined,
+    name: opts.name
+  });
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => issues,
+    set: () => {}
+  };
+}
+
+/**
+ * Slider standalone view — value is a `number` (single) or `number[]` (range).
+ * The bits-ui Slider has no native input, so there are no DOM events here; `set`
+ * is driven by the component's `onValueChange`.
+ */
+export function createLocalSliderView<T extends number | number[]>(opts: LocalOpts<T>): FieldView {
+  const issues = $derived.by(() => schemaIssues(opts.schema, opts.get()));
+  const attrs = $derived({
+    'aria-invalid': issues.length > 0 ? ('true' as const) : undefined,
+    name: opts.name,
+    value: opts.get() as unknown
+  });
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => issues,
+    set: (value) => {
+      opts.write(value as T);
+      opts.onInput?.(value as T);
+      opts.onChange?.(value as T);
+    }
+  };
+}
+
+/** Select standalone view — `set` receives the already-resolved typed value. */
+export function createLocalSelectView<T>(opts: LocalOpts<T>): FieldView {
+  const issues = $derived.by(() => schemaIssues(opts.schema, opts.get()));
+  const attrs = $derived({
+    'aria-invalid': issues.length > 0 ? ('true' as const) : undefined,
+    name: opts.name,
+    value: (opts.get() ?? '') as unknown
+  });
+  return {
+    get attrs() {
+      return attrs;
+    },
+    issues: () => issues,
+    set: (value) => {
+      opts.write(value as T);
+      opts.onInput?.(value as T);
+      opts.onChange?.(value as T);
+    }
+  };
+}

--- a/src/lib/shared/components/form/fields/CheckboxField.svelte
+++ b/src/lib/shared/components/form/fields/CheckboxField.svelte
@@ -1,37 +1,51 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import CheckIcon from '@lucide/svelte/icons/check';
   import { Checkbox } from 'bits-ui';
 
+  import { createFormView, createLocalCheckboxView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
 
-  type LooseField = {
-    as(type: 'checkbox'): {
-      'aria-invalid': 'false' | 'true' | boolean | undefined;
-      readonly checked: boolean;
-      name: string;
-      type: 'checkbox';
-      value?: string;
-    };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-    set(input: unknown): unknown;
-    value(): unknown;
-  };
-
   interface Props {
+    checked?: boolean;
     children?: Snippet;
     description?: string;
     disabled?: boolean;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: boolean) => void;
     optional?: boolean;
+    schema?: ZodType;
   }
 
-  let { children, description, disabled, form, name, optional }: Props = $props();
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('checkbox'));
+  let {
+    checked = $bindable(false),
+    children,
+    description,
+    disabled,
+    form,
+    name,
+    onChange,
+    optional,
+    schema
+  }: Props = $props();
+
+  // `as('checkbox')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'checkbox')
+    : createLocalCheckboxView({
+        get: () => checked,
+        name,
+        onChange,
+        schema,
+        write: (v) => (checked = v)
+      });
+
+  const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 </script>
 
@@ -41,14 +55,14 @@
       id={attrs.name}
       name={attrs.name}
       class="form-checkbox"
-      aria-invalid={attrs['aria-invalid']}
-      checked={attrs.checked}
+      aria-invalid={attrs['aria-invalid'] as 'false' | 'true' | boolean | undefined}
+      checked={attrs.checked as boolean}
       {disabled}
-      onCheckedChange={(v) => field.set(v === true)}
+      onCheckedChange={(v) => view.set(v === true)}
       {required}
     >
-      {#snippet children({ checked })}
-        {#if checked}
+      {#snippet children({ checked: isChecked })}
+        {#if isChecked}
           <CheckIcon class="form-checkbox-icon" />
         {/if}
       {/snippet}
@@ -62,7 +76,7 @@
   {#if description}
     <p class="form-description form-description--indented">{description}</p>
   {/if}
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error form-error--indented">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/DateField.svelte
+++ b/src/lib/shared/components/form/fields/DateField.svelte
@@ -1,17 +1,31 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, name, optional }: Props = $props();
+  let {
+    children,
+    form,
+    name,
+    onChange,
+    onInput,
+    optional,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {optional} type="date" />
+<Field {name} {children} {form} {onChange} {onInput} {optional} {schema} type="date" bind:value />

--- a/src/lib/shared/components/form/fields/DateRangeField.svelte
+++ b/src/lib/shared/components/form/fields/DateRangeField.svelte
@@ -1,29 +1,62 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
+  import { createFormView, createLocalTextView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: string): { [k: string]: unknown; name: string };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-  };
 
   interface Props {
     children?: Snippet;
     endName: keyof Input & string;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    endSchema?: ZodType;
+    endValue?: string;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    onChange?: (range: { end: string; start: string }) => void;
     optional?: boolean;
     startName: keyof Input & string;
+    startSchema?: ZodType;
+    startValue?: string;
   }
 
-  let { children, endName, form, optional, startName }: Props = $props();
+  let {
+    children,
+    endName,
+    endSchema,
+    endValue = $bindable(''),
+    form,
+    onChange,
+    optional,
+    startName,
+    startSchema,
+    startValue = $bindable('')
+  }: Props = $props();
+
+  // `as('date')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const startView: FieldView = form
+    ? createFormView(form, startName, 'date')
+    : createLocalTextView<string>({
+        get: () => startValue,
+        name: startName,
+        onInput: () => onChange?.({ end: endValue, start: startValue }),
+        schema: startSchema,
+        write: (v) => (startValue = v)
+      });
+  // svelte-ignore state_referenced_locally
+  const endView: FieldView = form
+    ? createFormView(form, endName, 'date')
+    : createLocalTextView<string>({
+        get: () => endValue,
+        name: endName,
+        onInput: () => onChange?.({ end: endValue, start: startValue }),
+        schema: endSchema,
+        write: (v) => (endValue = v)
+      });
 
   const required = $derived(!optional);
-  const startField = $derived((form.fields as Record<string, LooseField>)[startName]);
-  const endField = $derived((form.fields as Record<string, LooseField>)[endName]);
-  const startAttrs = $derived(startField.as('date'));
-  const endAttrs = $derived(endField.as('date'));
+  const startAttrs = $derived(startView.attrs);
+  const endAttrs = $derived(endView.attrs);
 </script>
 
 <div class="form-field">
@@ -41,10 +74,10 @@
     <span class="form-date-range-sep" aria-hidden="true">–</span>
     <input id={endAttrs.name} class="form-date-range-input" {required} type="date" {...endAttrs} />
   </div>
-  {#each startField.issues() ?? [] as issue (`start-${issue.path}`)}
+  {#each startView.issues() as issue (`start-${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
-  {#each endField.issues() ?? [] as issue (`end-${issue.path}`)}
+  {#each endView.issues() as issue (`end-${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/EmailField.svelte
+++ b/src/lib/shared/components/form/fields/EmailField.svelte
@@ -1,18 +1,44 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, name, optional, placeholder }: Props = $props();
+  let {
+    children,
+    form,
+    name,
+    onChange,
+    onInput,
+    optional,
+    placeholder,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {optional} {placeholder} type="email" />
+<Field
+  {name}
+  {children}
+  {form}
+  {onChange}
+  {onInput}
+  {optional}
+  {placeholder}
+  {schema}
+  type="email"
+  bind:value
+/>

--- a/src/lib/shared/components/form/fields/FileField.svelte
+++ b/src/lib/shared/components/form/fields/FileField.svelte
@@ -1,25 +1,23 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Upload from '@lucide/svelte/icons/upload';
 
+  import { createFormView, createLocalFileView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: string): { [k: string]: unknown; name: string };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-  };
 
   interface Props {
     accept?: string;
     children?: Snippet;
     disabled?: boolean;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     multiple?: boolean;
     name: keyof Input & string;
     onSelect?: (files: File[]) => void;
     optional?: boolean;
+    schema?: ZodType;
     variant?: 'button' | 'dropzone';
   }
 
@@ -32,18 +30,25 @@
     name,
     onSelect,
     optional,
+    schema,
     variant = 'button'
   }: Props = $props();
-
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('file'));
-  // required drives only the label asterisk here — the native `required` attribute is
-  // intentionally omitted from the file input (it blocks edit-form submits; see Zod validation).
-  const required = $derived(!optional);
 
   let input = $state<HTMLInputElement>();
   let files = $state<File[]>([]);
   let dragging = $state(false);
+
+  // `as('file')` is reached only via the `form` branch; standalone validates the
+  // selected files against the optional schema.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'file')
+    : createLocalFileView({ get: () => files, name, schema });
+
+  const attrs = $derived(view.attrs);
+  // required drives only the label asterisk here — the native `required` attribute is
+  // intentionally omitted from the file input (it blocks edit-form submits; see Zod validation).
+  const required = $derived(!optional);
 
   const label = $derived(
     files.length === 0
@@ -132,7 +137,7 @@
     </div>
   {/if}
 
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/HexColorField.svelte
+++ b/src/lib/shared/components/form/fields/HexColorField.svelte
@@ -1,51 +1,66 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import ColorPicker from 'svelte-awesome-color-picker';
 
+  import { createFormView, createLocalTextView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: 'text'): {
-      'aria-invalid': 'false' | 'true' | boolean | undefined;
-      name: string;
-      value: string;
-    };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-    set(input: string): unknown;
-    value(): string | undefined;
-  };
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: string) => void;
+    onInput?: (value: string) => void;
     optional?: boolean;
+    schema?: ZodType;
+    value?: string;
   }
 
-  let { children, form, name, optional }: Props = $props();
+  let {
+    children,
+    form,
+    name,
+    onChange,
+    onInput,
+    optional,
+    schema,
+    value = $bindable('')
+  }: Props = $props();
 
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('text'));
+  // `as('text')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'text')
+    : createLocalTextView<string>({
+        get: () => value,
+        name,
+        onChange,
+        onInput,
+        schema,
+        write: (v) => (value = v)
+      });
+
+  const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 
-  // ColorPicker expects '#rrggbb'; field stores without '#'. ColorPicker's hex
-  // prop has a fallback, so it must never be bound to undefined.
+  // Current stored value without the leading '#'.
+  const current = $derived(String(attrs.value ?? ''));
+
+  // ColorPicker expects '#rrggbb'; the field stores without '#'. ColorPicker's hex
+  // prop has a fallback, so it must never be bound to undefined. Writable derived:
+  // tracks the stored value, but ColorPicker can override it via `bind:hex`.
   const DEFAULT_HEX = '#000000';
-  let hex: string = $state(DEFAULT_HEX);
+  let hex: string = $derived(current ? `#${current}` : DEFAULT_HEX);
   let hiddenInput: HTMLInputElement | undefined = $state();
 
   $effect(() => {
-    const v = field.value();
-    hex = v ? `#${v}` : DEFAULT_HEX;
-  });
-
-  $effect(() => {
     const raw = hex.slice(1);
-    if (field.value() !== raw) {
-      if (field.value() == null && hex === DEFAULT_HEX) return;
-      field.set(raw);
+    if (current !== raw) {
+      if (!current && hex === DEFAULT_HEX) return;
+      view.set(raw);
       if (hiddenInput) {
         // Set DOM value synchronously before dispatching so handle_input reads the correct
         // value instead of the stale pre-update value, which would cause an infinite loop.
@@ -63,6 +78,6 @@
      Value is managed directly in the $effect above — not via reactive binding. -->
 <input bind:this={hiddenInput} name={attrs.name} type="hidden" />
 <ColorPicker isAlpha={false} position="responsive" bind:hex />
-{#each field.issues() ?? [] as issue (`${issue.path}`)}
+{#each view.issues() as issue (`${issue.path}`)}
   <p class="form-error">{issue.message}</p>
 {/each}

--- a/src/lib/shared/components/form/fields/MessageField.svelte
+++ b/src/lib/shared/components/form/fields/MessageField.svelte
@@ -1,26 +1,27 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import TextArea from '$lib/shared/components/ui/TextArea.svelte';
 
+  import { createFormView, createLocalTextView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: string): { [k: string]: unknown; name: string };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-  };
 
   interface Props {
     children?: Snippet;
     class?: string;
     defaultHeight?: number;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
     resize?: boolean;
+    schema?: ZodType;
+    value?: T;
   }
 
   let {
@@ -30,14 +31,27 @@
     form,
     icon,
     name,
+    onChange,
+    onInput,
     optional,
     placeholder,
-    resize = false
+    resize = false,
+    schema,
+    value = $bindable()
   }: Props = $props();
 
+  // `as('text')` is reached only via the `form` branch; standalone uses local state.
   // svelte-ignore state_referenced_locally
-  const field = (form.fields as Record<string, LooseField>)[name];
-  const attrs = field.as('text');
+  const view: FieldView = form
+    ? createFormView(form, name, 'text')
+    : createLocalTextView<T>({
+        get: () => value as T,
+        name,
+        onChange,
+        onInput,
+        schema,
+        write: (v) => (value = v)
+      });
 
   const required = $derived(!optional);
 
@@ -52,19 +66,19 @@
 
 <div class="form-field">
   {#if children}
-    <FieldLabel for={attrs.name} {required}>{@render children()}</FieldLabel>
+    <FieldLabel for={view.attrs.name} {required}>{@render children()}</FieldLabel>
   {/if}
   <TextArea
-    id={attrs.name}
+    id={view.attrs.name}
     class={className}
     {defaultHeight}
     {icon}
     placeholder={displayPlaceholder}
     {required}
     {resize}
-    {...attrs}
+    {...view.attrs}
   />
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/NumberField.svelte
+++ b/src/lib/shared/components/form/fields/NumberField.svelte
@@ -1,19 +1,47 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, icon, name, optional, placeholder }: Props = $props();
+  let {
+    children,
+    form,
+    icon,
+    name,
+    onChange,
+    onInput,
+    optional,
+    placeholder,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {icon} {optional} {placeholder} type="number" />
+<Field
+  {name}
+  {children}
+  {form}
+  {icon}
+  {onChange}
+  {onInput}
+  {optional}
+  {placeholder}
+  {schema}
+  type="number"
+  bind:value
+/>

--- a/src/lib/shared/components/form/fields/PasswordField.svelte
+++ b/src/lib/shared/components/form/fields/PasswordField.svelte
@@ -1,18 +1,44 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, name, optional, placeholder }: Props = $props();
+  let {
+    children,
+    form,
+    name,
+    onChange,
+    onInput,
+    optional,
+    placeholder,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {optional} {placeholder} type="password" />
+<Field
+  {name}
+  {children}
+  {form}
+  {onChange}
+  {onInput}
+  {optional}
+  {placeholder}
+  {schema}
+  type="password"
+  bind:value
+/>

--- a/src/lib/shared/components/form/fields/PinField.svelte
+++ b/src/lib/shared/components/form/fields/PinField.svelte
@@ -1,30 +1,27 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import MinusIcon from '@lucide/svelte/icons/minus';
   import { PinInput } from 'bits-ui';
 
+  import { createFormView, createLocalTextView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: 'text'): {
-      'aria-invalid': 'false' | 'true' | boolean | undefined;
-      name: string;
-      readonly value: number | string;
-    };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-  };
 
   interface Props {
     children?: Snippet;
     class?: string;
     description?: string;
     disabled?: boolean;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     maxlength?: number;
     name: keyof Input & string;
+    onChange?: (value: string) => void;
+    onInput?: (value: string) => void;
     optional?: boolean;
+    schema?: ZodType;
+    value?: string;
   }
 
   let {
@@ -35,11 +32,27 @@
     form,
     maxlength = 6,
     name,
-    optional
+    onChange,
+    onInput,
+    optional,
+    schema,
+    value = $bindable('')
   }: Props = $props();
 
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('text'));
+  // `as('text')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'text')
+    : createLocalTextView<string>({
+        get: () => value,
+        name,
+        onChange,
+        onInput,
+        schema,
+        write: (v) => (value = v)
+      });
+
+  const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 
   let pinValue = $derived(String(attrs.value ?? ''));
@@ -54,6 +67,7 @@
     class={['form-pin', className].filter(Boolean).join(' ')}
     {disabled}
     {maxlength}
+    onValueChange={(v) => view.set(v)}
     textalign="center"
     bind:value={pinValue}
   >
@@ -91,7 +105,7 @@
   {#if description}
     <p class="form-description">{description}</p>
   {/if}
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -1,25 +1,17 @@
 <script generics="Input extends RemoteFormInput, I, V, K extends number | string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
 
+  import { createFormView, createLocalSelectView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
-
-  type LooseField = {
-    as(type: 'select'): {
-      'aria-invalid': 'false' | 'true' | boolean | undefined;
-      name: string;
-      readonly value: string;
-    };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-    set(input: unknown): unknown;
-  };
 
   interface Props {
     children?: Snippet;
     class?: string;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     getKey: (item: I) => K;
     getLabel: (item: I) => string;
     getValue: (item: I) => V;
@@ -30,6 +22,8 @@
     onchange?: (value: undefined | V) => void;
     optional?: boolean;
     placeholder: string;
+    schema?: ZodType;
+    value?: undefined | V;
   }
 
   let {
@@ -45,11 +39,23 @@
     nullable = false,
     onchange,
     optional,
-    placeholder
+    placeholder,
+    schema,
+    value = $bindable()
   }: Props = $props();
 
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('select'));
+  // `as('select')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'select')
+    : createLocalSelectView<undefined | V>({
+        get: () => value,
+        name,
+        schema,
+        write: (v) => (value = v)
+      });
+
+  const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 
   // With a label the asterisk carries the required/optional cue; without one the
@@ -62,15 +68,22 @@
     new Map(items.map((item) => [String(getKey(item)), String(getValue(item))]))
   );
   const valueToItem = $derived(new Map(items.map((item) => [String(getValue(item)), item])));
+  const valueToKey = $derived(
+    new Map(items.map((item) => [String(getValue(item)), String(getKey(item))]))
+  );
 
-  const selectedValue = $derived(attrs.value);
+  // Form mode stores the submitted value string; standalone tracks the typed value,
+  // so the selected option is resolved from its key.
+  const selectedValue = $derived(
+    form ? (attrs.value as string) : (valueToKey.get(String(value ?? '')) ?? '')
+  );
 
   function handleChange(e: Event) {
     const key = (e.currentTarget as HTMLSelectElement).value;
     const newValue = keyToValue.get(key) ?? '';
     const item = valueToItem.get(newValue);
     const typedValue = item === undefined ? undefined : getValue(item);
-    field.set(typedValue);
+    view.set(typedValue);
     onchange?.(typedValue);
   }
 </script>
@@ -94,7 +107,7 @@
       ]
         .filter(Boolean)
         .join(' ')}
-      aria-invalid={attrs['aria-invalid']}
+      aria-invalid={attrs['aria-invalid'] as 'false' | 'true' | boolean | undefined}
       onchange={handleChange}
       {required}
       value={selectedValue}
@@ -106,7 +119,7 @@
     </select>
     <ChevronDown class="form-select-chevron" size={14} />
   </div>
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/SliderField.svelte
+++ b/src/lib/shared/components/form/fields/SliderField.svelte
@@ -1,0 +1,182 @@
+<script generics="Input extends RemoteFormInput" lang="ts">
+  import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
+  import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
+
+  import { Slider } from 'bits-ui';
+
+  import { createFormView, createLocalSliderView, type FieldView } from '../field-view.svelte.js';
+  import FieldLabel from '../FieldLabel.svelte';
+
+  interface Props {
+    children?: Snippet;
+    disabled?: boolean;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    /** Range + form mode: field name for the upper thumb. */
+    highName?: keyof Input & string;
+    /** Range + form mode: field name for the lower thumb. */
+    lowName?: keyof Input & string;
+    max?: number;
+    min?: number;
+    /** Single mode field name. */
+    name?: keyof Input & string;
+    onChange?: (value: number | number[]) => void;
+    optional?: boolean;
+    /** Dual-thumb range slider; `value` becomes `[low, high]`. */
+    range?: boolean;
+    schema?: ZodType;
+    /** Show the current value next to the label (default true). */
+    showValue?: boolean;
+    step?: number;
+    value?: number | number[];
+  }
+
+  let {
+    children,
+    disabled = false,
+    form,
+    highName,
+    lowName,
+    max = 100,
+    min = 0,
+    name,
+    onChange,
+    optional,
+    range = false,
+    schema,
+    showValue = true,
+    step = 1,
+    value = $bindable(range ? [min, max] : min)
+  }: Props = $props();
+
+  // `as('number')` is reached only via the `form` branch; standalone uses local state.
+  // The branch (single/range, form/standalone) is fixed for a field instance.
+  // svelte-ignore state_referenced_locally
+  const singleView: FieldView | undefined = range
+    ? undefined
+    : form
+      ? createFormView(form, name as string, 'number')
+      : createLocalSliderView<number>({
+          get: () => (value as number) ?? min,
+          name: (name as string) ?? 'slider',
+          onChange: (v) => onChange?.(v),
+          schema,
+          write: (v) => (value = v)
+        });
+  // svelte-ignore state_referenced_locally
+  const lowView: FieldView | undefined =
+    range && form ? createFormView(form, lowName as string, 'number') : undefined;
+  // svelte-ignore state_referenced_locally
+  const highView: FieldView | undefined =
+    range && form ? createFormView(form, highName as string, 'number') : undefined;
+  // svelte-ignore state_referenced_locally
+  const rangeLocalView: FieldView | undefined =
+    range && !form
+      ? createLocalSliderView<number[]>({
+          get: () => (value as number[]) ?? [min, max],
+          name: (lowName as string) ?? 'slider',
+          onChange: (v) => onChange?.(v),
+          schema,
+          write: (v) => (value = v)
+        })
+      : undefined;
+
+  const required = $derived(!optional);
+  const labelFor = $derived((name as string) ?? (lowName as string) ?? 'slider');
+
+  const singleValue = $derived(Number(singleView?.attrs.value ?? min));
+  const rangeValue = $derived.by<number[]>(() =>
+    rangeLocalView
+      ? ((rangeLocalView.attrs.value as number[]) ?? [min, max])
+      : [Number(lowView?.attrs.value ?? min), Number(highView?.attrs.value ?? max)]
+  );
+
+  const issues = $derived(
+    range
+      ? rangeLocalView
+        ? rangeLocalView.issues()
+        : [...(lowView?.issues() ?? []), ...(highView?.issues() ?? [])]
+      : (singleView?.issues() ?? [])
+  );
+
+  function handleSingle(v: number) {
+    singleView?.set(v);
+  }
+
+  function handleRange(v: number[]) {
+    if (rangeLocalView) {
+      rangeLocalView.set(v);
+    } else {
+      lowView?.set(v[0]);
+      highView?.set(v[1]);
+    }
+  }
+</script>
+
+<div class="form-slider-wrapper">
+  <div class="form-slider-row">
+    {#if children}
+      <FieldLabel class="form-slider-label" for={labelFor} {required}>
+        {@render children()}
+      </FieldLabel>
+    {/if}
+    {#if showValue}
+      <span class="form-slider-value"
+        >{range ? `${rangeValue[0]} – ${rangeValue[1]}` : singleValue}</span
+      >
+    {/if}
+  </div>
+
+  {#if range}
+    <Slider.Root
+      id={labelFor}
+      class="form-slider"
+      {disabled}
+      {max}
+      {min}
+      onValueChange={handleRange}
+      {step}
+      type="multiple"
+      value={rangeValue}
+    >
+      {#snippet children({ thumbs })}
+        <span class="form-slider-track"><Slider.Range class="form-slider-range" /></span>
+        {#each thumbs as index (index)}
+          <Slider.Thumb class="form-slider-thumb" {index} />
+        {/each}
+      {/snippet}
+    </Slider.Root>
+  {:else}
+    <Slider.Root
+      id={labelFor}
+      class="form-slider"
+      {disabled}
+      {max}
+      {min}
+      onValueChange={handleSingle}
+      {step}
+      type="single"
+      value={singleValue}
+    >
+      {#snippet children({ thumbs })}
+        <span class="form-slider-track"><Slider.Range class="form-slider-range" /></span>
+        {#each thumbs as index (index)}
+          <Slider.Thumb class="form-slider-thumb" {index} />
+        {/each}
+      {/snippet}
+    </Slider.Root>
+  {/if}
+
+  {#if form}
+    {#if range}
+      <input name={lowView?.attrs.name} type="hidden" value={rangeValue[0]} />
+      <input name={highView?.attrs.name} type="hidden" value={rangeValue[1]} />
+    {:else}
+      <input name={singleView?.attrs.name} type="hidden" value={singleValue} />
+    {/if}
+  {/if}
+
+  {#each issues as issue (`${issue.path}`)}
+    <p class="form-error form-error--indented">{issue.message}</p>
+  {/each}
+</div>

--- a/src/lib/shared/components/form/fields/SwitchField.svelte
+++ b/src/lib/shared/components/form/fields/SwitchField.svelte
@@ -1,35 +1,59 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import { Switch } from 'bits-ui';
 
+  import { createFormView, createLocalCheckboxView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
 
-  type LooseField = {
-    as(type: 'checkbox'): {
-      'aria-invalid': 'false' | 'true' | boolean | undefined;
-      readonly checked: boolean;
-      name: string;
-      type: 'checkbox';
-      value?: string;
-    };
-    issues(): Array<{ message: string; path: Array<number | string> }> | undefined;
-    set(input: unknown): unknown;
-  };
-
   interface Props {
+    checked?: boolean;
     children?: Snippet;
     description?: string;
     disabled?: boolean;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    /** Label shown in the `toggle` variant when unchecked (default "OFF"). */
+    offLabel?: string;
+    onChange?: (value: boolean) => void;
+    /** Label shown in the `toggle` variant when checked (default "ON"). */
+    onLabel?: string;
     optional?: boolean;
+    schema?: ZodType;
+    /** `switch` is the sliding pill (default); `toggle` is the ON/OFF labelled style. */
+    variant?: 'switch' | 'toggle';
   }
 
-  let { children, description, disabled, form, name, optional }: Props = $props();
-  const field = $derived((form.fields as Record<string, LooseField>)[name]);
-  const attrs = $derived(field.as('checkbox'));
+  let {
+    checked = $bindable(false),
+    children,
+    description,
+    disabled,
+    form,
+    name,
+    offLabel = 'OFF',
+    onChange,
+    onLabel = 'ON',
+    optional,
+    schema,
+    variant = 'switch'
+  }: Props = $props();
+
+  // `as('checkbox')` is reached only via the `form` branch; standalone uses local state.
+  // svelte-ignore state_referenced_locally
+  const view: FieldView = form
+    ? createFormView(form, name, 'checkbox')
+    : createLocalCheckboxView({
+        get: () => checked,
+        name,
+        onChange,
+        schema,
+        write: (v) => (checked = v)
+      });
+
+  const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 </script>
 
@@ -43,20 +67,26 @@
     <Switch.Root
       id={attrs.name}
       name={attrs.name}
-      class="form-switch"
-      aria-invalid={attrs['aria-invalid']}
-      checked={attrs.checked}
+      class={variant === 'toggle' ? 'form-toggle' : 'form-switch'}
+      aria-invalid={attrs['aria-invalid'] as 'false' | 'true' | boolean | undefined}
+      checked={attrs.checked as boolean}
       {disabled}
-      onCheckedChange={(v) => field.set(v === true)}
+      onCheckedChange={(v) => view.set(v === true)}
       {required}
     >
-      <Switch.Thumb class="form-switch-thumb" />
+      {#if variant === 'toggle'}
+        <span class="form-toggle-text form-toggle-text--on">{onLabel}</span>
+        <span class="form-toggle-text form-toggle-text--off">{offLabel}</span>
+        <Switch.Thumb class="form-toggle-thumb" />
+      {:else}
+        <Switch.Thumb class="form-switch-thumb" />
+      {/if}
     </Switch.Root>
   </div>
   {#if description}
     <p class="form-description form-description--indented">{description}</p>
   {/if}
-  {#each field.issues() ?? [] as issue (`${issue.path}`)}
+  {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error form-error--indented">{issue.message}</p>
   {/each}
 </div>

--- a/src/lib/shared/components/form/fields/TextField.svelte
+++ b/src/lib/shared/components/form/fields/TextField.svelte
@@ -1,19 +1,47 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
     placeholder?: string;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, icon, name, optional, placeholder }: Props = $props();
+  let {
+    children,
+    form,
+    icon,
+    name,
+    onChange,
+    onInput,
+    optional,
+    placeholder,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {icon} {optional} {placeholder} type="text" />
+<Field
+  {name}
+  {children}
+  {form}
+  {icon}
+  {onChange}
+  {onInput}
+  {optional}
+  {placeholder}
+  {schema}
+  type="text"
+  bind:value
+/>

--- a/src/lib/shared/components/form/fields/TimeField.svelte
+++ b/src/lib/shared/components/form/fields/TimeField.svelte
@@ -1,17 +1,31 @@
-<script generics="Input extends RemoteFormInput" lang="ts">
+<script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
     children?: Snippet;
-    form: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
+    form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
+    onChange?: (value: T) => void;
+    onInput?: (value: T) => void;
     optional?: boolean;
+    schema?: ZodType;
+    value?: T;
   }
 
-  let { children, form, name, optional }: Props = $props();
+  let {
+    children,
+    form,
+    name,
+    onChange,
+    onInput,
+    optional,
+    schema,
+    value = $bindable()
+  }: Props = $props();
 </script>
 
-<Field {name} {children} {form} {optional} type="time" />
+<Field {name} {children} {form} {onChange} {onInput} {optional} {schema} type="time" bind:value />

--- a/src/lib/shared/components/form/index.ts
+++ b/src/lib/shared/components/form/index.ts
@@ -10,6 +10,7 @@ export { default as NumberField } from './fields/NumberField.svelte';
 export { default as PasswordField } from './fields/PasswordField.svelte';
 export { default as PinField } from './fields/PinField.svelte';
 export { default as SelectField } from './fields/SelectField.svelte';
+export { default as SliderField } from './fields/SliderField.svelte';
 export { default as SwitchField } from './fields/SwitchField.svelte';
 export { default as TextField } from './fields/TextField.svelte';
 export { default as TimeField } from './fields/TimeField.svelte';

--- a/src/routes/fields/+page.svelte
+++ b/src/routes/fields/+page.svelte
@@ -17,6 +17,7 @@
     PasswordField,
     PinField,
     SelectField,
+    SliderField,
     SwitchField,
     TextField,
     TimeField
@@ -24,6 +25,7 @@
   import { Sidebar } from '$lib/shared/components/ui/index.js';
   import { Hash, MessageSquare, Tag, User } from '@lucide/svelte';
   import { identity } from 'ramda';
+  import { z } from 'zod/v4';
 
   import {
     checkboxForm,
@@ -44,6 +46,7 @@
     selectForm,
     selectNullableForm,
     showcaseForm,
+    sliderForm,
     textForm,
     textNullableForm,
     timeForm
@@ -68,6 +71,7 @@
     SelectNullableSchema,
     SelectSchema,
     ShowcaseSchema,
+    SliderSchema,
     TextNullableSchema,
     TextSchema,
     TimeSchema
@@ -75,7 +79,39 @@
 
   let hiddenToken = $state<string | undefined>('abc123');
   let hiddenCount = $state<string | undefined>('1');
+
+  // Standalone (no form) demo state. Fields are controlled via bind:value /
+  // bind:checked, validate against an optional per-field Zod schema, and fire
+  // onInput / onChange callbacks.
+  let saText = $state('');
+  let saEmail = $state('');
+  let saPassword = $state('');
+  let saNumber = $state('');
+  let saDate = $state('');
+  let saTime = $state('');
+  let saChecked = $state(false);
+  let saSwitch = $state(false);
+  let saColor = $state('');
+  let saMessage = $state('');
+  let saPin = $state('');
+  let saSelect = $state<string | undefined>(undefined);
+  let saStartDate = $state('');
+  let saEndDate = $state('');
+  let saFiles = $state<File[]>([]);
+  let saSlider = $state(25);
+  let saSliderRange = $state<number[]>([20, 80]);
+
+  const StandaloneText = z.string().min(3, 'Minimum 3 characters');
+  const StandaloneEmail = z.email('Invalid email');
+  const StandaloneMessage = z.string().min(10, 'Minimum 10 characters');
+  const StandaloneFiles = z.array(z.instanceof(File)).min(1, 'Select at least one file');
 </script>
+
+{#snippet standaloneLabel(note?: string)}
+  <p class="mt-6 mb-3 border-t border-gray-200 pt-4 text-xs font-semibold text-gray-500">
+    Standalone (no form){note ? ` — ${note}` : ''}
+  </p>
+{/snippet}
 
 <Sidebar.Provider>
   <Sidebar.Root>
@@ -87,7 +123,7 @@
         <Sidebar.GroupLabel>New (Remote Forms)</Sidebar.GroupLabel>
         <Sidebar.GroupContent>
           <Sidebar.Menu>
-            {#each [['textfield', 'TextField'], ['emailfield', 'EmailField'], ['passwordfield', 'PasswordField'], ['numberfield', 'NumberField'], ['datefield', 'DateField'], ['daterangefield', 'DateRangeField'], ['timefield', 'TimeField'], ['checkboxfield', 'CheckboxField'], ['hexcolorfield', 'HexColorField'], ['messagefield', 'MessageField'], ['pinfield', 'PinField'], ['selectfield', 'SelectField'], ['filefield', 'FileField'], ['hidden-inputs', 'Hidden inputs'], ['form', 'Form']] as [anchor, label] (anchor)}
+            {#each [['textfield', 'TextField'], ['emailfield', 'EmailField'], ['passwordfield', 'PasswordField'], ['numberfield', 'NumberField'], ['datefield', 'DateField'], ['daterangefield', 'DateRangeField'], ['timefield', 'TimeField'], ['checkboxfield', 'CheckboxField'], ['hexcolorfield', 'HexColorField'], ['messagefield', 'MessageField'], ['pinfield', 'PinField'], ['selectfield', 'SelectField'], ['sliderfield', 'SliderField'], ['filefield', 'FileField'], ['hidden-inputs', 'Hidden inputs'], ['form', 'Form']] as [anchor, label] (anchor)}
               <Sidebar.MenuItem>
                 <Sidebar.MenuButton>
                   {#snippet child({ props })}
@@ -156,6 +192,17 @@
             <TextField name="text" form={textNullableForm} optional placeholder="no label" />
             <Button form={textNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value + schema + onInput')}
+          <TextField
+            name="text"
+            onInput={(v) => (saText = v)}
+            placeholder="min 3 chars"
+            schema={StandaloneText}
+            bind:value={saText}
+          >
+            Text
+          </TextField>
+          <p class="mt-1 text-xs text-gray-600">value: {saText || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<TextField name="text" form={remoteForm}>Text</TextField>
@@ -182,6 +229,9 @@
             </EmailField>
             <Button form={emailNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value + schema')}
+          <EmailField name="email" schema={StandaloneEmail} bind:value={saEmail}>Email</EmailField>
+          <p class="mt-1 text-xs text-gray-600">value: {saEmail || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<EmailField name="email" form={remoteForm}>Email</EmailField>
@@ -197,6 +247,9 @@
             >
             <Button form={passwordForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <PasswordField name="password" bind:value={saPassword}>Password</PasswordField>
+          <p class="mt-1 text-xs text-gray-600">length: {saPassword.length}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<PasswordField name="password" form={remoteForm}>Password</PasswordField>`}
@@ -234,6 +287,9 @@
             </NumberField>
             <Button form={numberNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <NumberField name="age" placeholder="any number" bind:value={saNumber}>Age</NumberField>
+          <p class="mt-1 text-xs text-gray-600">value: {saNumber || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<NumberField name="age" form={remoteForm}>Age</NumberField>
@@ -247,6 +303,9 @@
             <DateField name="date" form={dateForm}>Date (2026 or later)</DateField>
             <Button form={dateForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <DateField name="date" bind:value={saDate}>Date</DateField>
+          <p class="mt-1 text-xs text-gray-600">value: {saDate || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<DateField name="date" form={remoteForm}>Date</DateField>`}
@@ -261,6 +320,18 @@
             </DateRangeField>
             <Button form={dateRangeForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:startValue / bind:endValue')}
+          <DateRangeField
+            endName="endDate"
+            startName="startDate"
+            bind:endValue={saEndDate}
+            bind:startValue={saStartDate}
+          >
+            Date range
+          </DateRangeField>
+          <p class="mt-1 text-xs text-gray-600">
+            {saStartDate || '(empty)'} → {saEndDate || '(empty)'}
+          </p>
         </Preview>
         <CodeBlock slot="code">
           {`<DateRangeField startName="startDate" endName="endDate" form={remoteForm}>
@@ -275,6 +346,9 @@
             <TimeField name="time" form={timeForm}>Time (afternoon, 12:00+)</TimeField>
             <Button form={timeForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <TimeField name="time" bind:value={saTime}>Time</TimeField>
+          <p class="mt-1 text-xs text-gray-600">value: {saTime || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<TimeField name="time" form={remoteForm}>Time</TimeField>`}
@@ -355,10 +429,43 @@
             </SwitchField>
             <Button form={checkboxForm.for('switch-disabled')}>Submit</Button>
           </Form>
+          <Form
+            class="mt-4 flex flex-col gap-4"
+            form={checkboxForm.for('toggle')}
+            schema={CheckboxSchema}
+          >
+            <SwitchField name="agreed" form={checkboxForm.for('toggle')} variant="toggle">
+              As an ON/OFF toggle
+            </SwitchField>
+            <Button form={checkboxForm.for('toggle')}>Submit</Button>
+          </Form>
+          {@render standaloneLabel('bind:checked + onChange')}
+          <CheckboxField name="agreed" onChange={(v) => (saChecked = v)} bind:checked={saChecked}>
+            I agree
+          </CheckboxField>
+          <SwitchField name="enabled" bind:checked={saSwitch}>As a switch</SwitchField>
+          <SwitchField name="enabled" variant="toggle" bind:checked={saSwitch}>
+            As an ON/OFF toggle
+          </SwitchField>
+          <SwitchField
+            name="power"
+            offLabel="NO"
+            onLabel="YES"
+            variant="toggle"
+            bind:checked={saSwitch}
+          >
+            Custom labels
+          </SwitchField>
+          <p class="mt-1 text-xs text-gray-600">checkbox: {saChecked} · switch: {saSwitch}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<CheckboxField name="agreed" form={remoteForm}>I agree to the terms</CheckboxField>
-<CheckboxField name="agreed" form={remoteForm} optional>Optional</CheckboxField>`}
+<CheckboxField name="agreed" form={remoteForm} optional>Optional</CheckboxField>
+
+<!-- switch (default) vs ON/OFF toggle variant -->
+<SwitchField name="enabled" bind:checked>As a switch</SwitchField>
+<SwitchField name="enabled" variant="toggle" bind:checked>Toggle</SwitchField>
+<SwitchField name="power" variant="toggle" onLabel="YES" offLabel="NO" bind:checked>Custom</SwitchField>`}
         </CodeBlock>
       </Container>
 
@@ -378,6 +485,9 @@
             </HexColorField>
             <Button form={colorNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <HexColorField name="color" bind:value={saColor}>Color</HexColorField>
+          <p class="mt-1 text-xs text-gray-600">value: {saColor || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<HexColorField name="color" form={remoteForm}>Color</HexColorField>
@@ -416,6 +526,11 @@
             </MessageField>
             <Button form={messageForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value + schema')}
+          <MessageField name="message" schema={StandaloneMessage} bind:value={saMessage}>
+            Message
+          </MessageField>
+          <p class="mt-1 text-xs text-gray-600">length: {saMessage.length}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<MessageField
@@ -457,6 +572,9 @@
             <PinField name="pin" form={pinNullableForm} optional>PIN (optional)</PinField>
             <Button form={pinNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value')}
+          <PinField name="pin" bind:value={saPin}>PIN</PinField>
+          <p class="mt-1 text-xs text-gray-600">value: {saPin || '(empty)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<PinField name="pin" form={remoteForm} maxlength={6}>
@@ -520,6 +638,19 @@
             </SelectField>
             <Button form={selectNullableForm}>Submit</Button>
           </Form>
+          {@render standaloneLabel('bind:value + onchange')}
+          <SelectField
+            name="select"
+            getKey={identity}
+            getLabel={(s: string) => s.toUpperCase()}
+            getValue={identity}
+            items={['apple', 'banana', 'cherry']}
+            placeholder="Please select"
+            bind:value={saSelect}
+          >
+            Select
+          </SelectField>
+          <p class="mt-1 text-xs text-gray-600">value: {saSelect ?? '(none)'}</p>
         </Preview>
         <CodeBlock slot="code">
           {`<SelectField
@@ -534,6 +665,42 @@
   Select
 </SelectField>
 <SelectField name="select" form={remoteForm} nullable optional ...>Select</SelectField>`}
+        </CodeBlock>
+      </Container>
+
+      <Container
+        description="A range slider (single or dual-thumb) styled like the switch"
+        title="SliderField"
+      >
+        <Preview slot="preview">
+          <Form class="flex flex-col gap-4" form={sliderForm} schema={SliderSchema}>
+            <SliderField name="level" form={sliderForm}>Level (set 50 or higher)</SliderField>
+            <Button form={sliderForm}>Submit</Button>
+          </Form>
+          {@render standaloneLabel('single — bind:value + onChange')}
+          <SliderField
+            name="level"
+            onChange={(v) => (saSlider = v as number)}
+            bind:value={saSlider}
+          >
+            Volume
+          </SliderField>
+          <p class="mt-1 text-xs text-gray-600">value: {saSlider}</p>
+          {@render standaloneLabel('range — bind:value=[low, high]')}
+          <SliderField name="price" range bind:value={saSliderRange}>Price</SliderField>
+          <p class="mt-1 text-xs text-gray-600">
+            range: {saSliderRange[0]} – {saSliderRange[1]}
+          </p>
+        </Preview>
+        <CodeBlock slot="code">
+          {`<!-- form mode -->
+<SliderField name="level" form={remoteForm}>Level</SliderField>
+
+<!-- standalone single -->
+<SliderField name="volume" bind:value min={0} max={100} step={1}>Volume</SliderField>
+
+<!-- standalone dual-thumb range -->
+<SliderField name="price" range bind:value={[low, high]}>Price</SliderField>`}
         </CodeBlock>
       </Container>
 
@@ -562,6 +729,13 @@
             </FileField>
             <Button form={fileForm.for('dropzone')}>Submit</Button>
           </Form>
+          {@render standaloneLabel('onSelect + schema')}
+          <FileField name="file" multiple onSelect={(f) => (saFiles = f)} schema={StandaloneFiles}>
+            Upload
+          </FileField>
+          <p class="mt-1 text-xs text-gray-600">
+            selected: {saFiles.length === 0 ? '(none)' : saFiles.map((f) => f.name).join(', ')}
+          </p>
         </Preview>
         <CodeBlock slot="code">
           {`<!-- required by default; the asterisk shows but the native input is never marked

--- a/src/routes/fields/action.remote.ts
+++ b/src/routes/fields/action.remote.ts
@@ -20,6 +20,7 @@ import {
   SelectNullableSchema,
   SelectSchema,
   ShowcaseSchema,
+  SliderSchema,
   TextNullableSchema,
   TextSchema,
   TimeSchema
@@ -83,6 +84,10 @@ export const dateRangeForm = form(DateRangeSchema, async (data) => {
 
 export const fileForm = form(FileSchema, async (data) =>
   ok({ name: data.file.name, size: data.file.size })
+);
+
+export const sliderForm = form(SliderSchema, async (data) =>
+  data.level >= 50 ? ok(data) : fail(data, 'Set the level to 50 or higher')
 );
 
 export const hiddenForm = form(HiddenSchema, async (data) => ok(data));

--- a/src/routes/fields/schemas.ts
+++ b/src/routes/fields/schemas.ts
@@ -33,6 +33,7 @@ export const ColorSchema = z.object({ color: formHexColor });
 export const MessageSchema = z.object({ message: formText });
 export const PinSchema = z.object({ pin: formPin() });
 export const SelectSchema = z.object({ select: formSelect(SELECT_OPTIONS) });
+export const SliderSchema = z.object({ level: formNumber.pipe(z.number().min(0).max(100)) });
 export const HiddenSchema = z.object({
   count: formNumber,
   label: formText,

--- a/src/template.css
+++ b/src/template.css
@@ -206,6 +206,157 @@
   transform: translateX(18px);
 }
 
+.form-toggle {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  width: 60px;
+  height: 22px;
+  border: none;
+  border-radius: 0;
+  background: var(--bd);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  outline: none;
+}
+
+.form-toggle[data-state='checked'] {
+  background: var(--tx);
+}
+
+.form-toggle[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-toggle:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tx) 15%, transparent);
+}
+
+.form-toggle-text {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.form-toggle-text--on {
+  left: 2px;
+  color: var(--bg);
+  opacity: 0;
+}
+
+.form-toggle-text--off {
+  right: 2px;
+  color: var(--tx);
+  opacity: 1;
+}
+
+.form-toggle[data-state='checked'] .form-toggle-text--on {
+  opacity: 1;
+}
+
+.form-toggle[data-state='checked'] .form-toggle-text--off {
+  opacity: 0;
+}
+
+.form-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 28px;
+  height: 18px;
+  border-radius: 0;
+  background: var(--bg);
+  transition: transform 0.15s ease;
+  pointer-events: none;
+}
+
+.form-toggle[data-state='checked'] .form-toggle-thumb {
+  transform: translateX(28px);
+}
+
+.form-slider-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-slider-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.form-slider-label {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--tx);
+}
+
+.form-slider-value {
+  font-size: 12px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--tx);
+}
+
+.form-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 20px;
+  touch-action: none;
+  user-select: none;
+}
+
+.form-slider[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-slider-track {
+  position: relative;
+  width: 100%;
+  height: 4px;
+  background: var(--bd);
+}
+
+.form-slider-range {
+  position: absolute;
+  height: 100%;
+  background: var(--tx);
+}
+
+.form-slider-thumb {
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 0;
+  background: var(--tx);
+  cursor: grab;
+  outline: none;
+}
+
+.form-slider-thumb:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tx) 15%, transparent);
+}
+
+.form-slider-thumb:active {
+  cursor: grabbing;
+}
+
 .form-input-wrapper {
   position: relative;
 }


### PR DESCRIPTION
## Summary

Makes every form field usable **without** a `RemoteForm`, adds a new **SliderField**, and gives **SwitchField** an ON/OFF toggle variant. Existing form-driven usage is unchanged.

### Form-optional fields
- New `field-view.svelte.ts` — one `FieldView` contract, two sources: `createFormView` (wraps `form.fields[name]`) and `createLocal*View` (text/checkbox/select/file/slider) backed by `bind:value`/`bind:checked`.
- **`as()` is reached only via the `form` branch**, so standalone fields never call it (a `form ? … : …` guard).
- Every field gains: optional `form`, standalone `bind:value`/`bind:checked`, optional per-field Zod `schema`, and `onInput`/`onChange` callbacks.
- `DateRangeField` + `FileField` converted too.

### SliderField (new)
- bits-ui `Slider`, switch-style row (label + value + track).
- Single by default; `range` prop → dual-thumb (`value` becomes `[low, high]`).
- Form mode submits via hidden input(s); standalone via `bind:value`. `min`/`max`/`step`, `disabled`, `showValue`.

### SwitchField ON/OFF variant
- Same component, `variant="toggle"` swaps to an ON/OFF labelled style (`onLabel`/`offLabel`). Default `variant="switch"` unchanged.

### Showcase
- Each field section now shows its standalone (no-form) counterpart alongside the form examples.
- New `SliderField` section; toggle-variant demos in the switch section.
- `.form-slider-*` and `.form-toggle-*` styles added to `template.css`.

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings, 165 tests pass
- [x] `svelte-autofixer` clean on all touched components
- [ ] Manual: `/fields` — form submit + standalone `bind:value`, slider single/range, switch toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)