### PR TITLE
fix: placeholder cue — drop (Required), suffix (Optional)

### DIFF
--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -63,7 +63,7 @@
   const displayPlaceholder = $derived(
     children || required
       ? placeholder
-      : placeholder != null
+      : placeholder
         ? `${placeholder} (Optional)`
         : '(Optional)'
   );

--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -61,11 +61,7 @@
   // required fields just show the placeholder; optional fields get an (Optional)
   // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children || required
-      ? placeholder
-      : placeholder
-        ? `${placeholder} (Optional)`
-        : '(Optional)'
+    children || required ? placeholder : placeholder ? `${placeholder} (Optional)` : '(Optional)'
   );
 </script>
 

--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -57,12 +57,15 @@
 
   const required = $derived(!optional);
 
-  // With a label the asterisk carries the required/optional cue; without one the
-  // placeholder does, so prefix it with (Required) / (Optional).
+  // With a label the asterisk carries the required/optional cue. Without one,
+  // required fields just show the placeholder; optional fields get an (Optional)
+  // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children
+    children || required
       ? placeholder
-      : `(${required ? 'Required' : 'Optional'})${placeholder != null ? ` ${placeholder}` : ''}`
+      : placeholder != null
+        ? `${placeholder} (Optional)`
+        : '(Optional)'
   );
 </script>
 

--- a/src/lib/shared/components/form/fields/MessageField.svelte
+++ b/src/lib/shared/components/form/fields/MessageField.svelte
@@ -59,11 +59,7 @@
   // required fields just show the placeholder; optional fields get an (Optional)
   // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children || required
-      ? placeholder
-      : placeholder
-        ? `${placeholder} (Optional)`
-        : '(Optional)'
+    children || required ? placeholder : placeholder ? `${placeholder} (Optional)` : '(Optional)'
   );
 </script>
 

--- a/src/lib/shared/components/form/fields/MessageField.svelte
+++ b/src/lib/shared/components/form/fields/MessageField.svelte
@@ -55,12 +55,15 @@
 
   const required = $derived(!optional);
 
-  // With a label the asterisk carries the required/optional cue; without one the
-  // placeholder does, so prefix it with (Required) / (Optional).
+  // With a label the asterisk carries the required/optional cue. Without one,
+  // required fields just show the placeholder; optional fields get an (Optional)
+  // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children
+    children || required
       ? placeholder
-      : `(${required ? 'Required' : 'Optional'})${placeholder != null ? ` ${placeholder}` : ''}`
+      : placeholder != null
+        ? `${placeholder} (Optional)`
+        : '(Optional)'
   );
 </script>
 

--- a/src/lib/shared/components/form/fields/MessageField.svelte
+++ b/src/lib/shared/components/form/fields/MessageField.svelte
@@ -61,7 +61,7 @@
   const displayPlaceholder = $derived(
     children || required
       ? placeholder
-      : placeholder != null
+      : placeholder
         ? `${placeholder} (Optional)`
         : '(Optional)'
   );

--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -58,10 +58,11 @@
   const attrs = $derived(view.attrs);
   const required = $derived(!optional);
 
-  // With a label the asterisk carries the required/optional cue; without one the
-  // placeholder option does, so prefix it with (Required) / (Optional).
+  // With a label the asterisk carries the required/optional cue. Without one,
+  // required fields just show the placeholder; optional fields get an (Optional)
+  // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children ? placeholder : `(${required ? 'Required' : 'Optional'}) ${placeholder}`
+    children || required ? placeholder : `${placeholder} (Optional)`
   );
 
   const keyToValue = $derived(

--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -62,7 +62,7 @@
   // required fields just show the placeholder; optional fields get an (Optional)
   // suffix so the cue reads naturally after the placeholder text.
   const displayPlaceholder = $derived(
-    children || required ? placeholder : `${placeholder} (Optional)`
+    children || required || !placeholder ? placeholder : `${placeholder} (Optional)`
   );
 
   const keyToValue = $derived(


### PR DESCRIPTION
## What

For label-less fields, the placeholder showed a leading `(Required)` / `(Optional)` prefix. This looked odd.

- **Required** (no label) → bare placeholder, no `(Required)`.
- **Optional** (no label) → `(Optional)` as a suffix, e.g. `Phone number (Optional)`.
- **With label** → unchanged; asterisk carries the cue.

## Files

- `form/Field.svelte`
- `form/fields/MessageField.svelte`
- `form/fields/SelectField.svelte`

## Checks

`pnpm lint:svelte` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)