### PR TITLE
fix: make `optional` cosmetic on boolean fields

### DIFF
--- a/src/lib/shared/components/form/fields/CheckboxField.svelte
+++ b/src/lib/shared/components/form/fields/CheckboxField.svelte
@@ -59,7 +59,6 @@
       checked={attrs.checked as boolean}
       {disabled}
       onCheckedChange={(v) => view.set(v === true)}
-      {required}
     >
       {#snippet children({ checked: isChecked })}
         {#if isChecked}

--- a/src/lib/shared/components/form/fields/SwitchField.svelte
+++ b/src/lib/shared/components/form/fields/SwitchField.svelte
@@ -72,7 +72,6 @@
       checked={attrs.checked as boolean}
       {disabled}
       onCheckedChange={(v) => view.set(v === true)}
-      {required}
     >
       {#if variant === 'toggle'}
         <span class="form-toggle-text form-toggle-text--on">{onLabel}</span>


### PR DESCRIPTION
## Problem

`CheckboxField` and `SwitchField` passed `required={!optional}` to the underlying bits-ui control (`Checkbox.Root` / `Switch.Root`). bits-ui renders a hidden native input carrying the HTML `required` attribute. For a checkbox, HTML `required` means the box **must be checked** to pass browser validation — so an unchecked (`false`) boolean blocked form submission unless `optional` was explicitly set.

`optional` was meant to be a cosmetic argument (label cue) for any field, not an actual submit restriction. A `false` boolean is a valid value.

## Fix

- Drop `{required}` from `Checkbox.Root` and `Switch.Root`.
- Keep `required` on `FieldLabel` so `optional` still drives the label cue only.
- Real validation stays with the Zod schema server-side.

## Verification

`pnpm lint:svelte` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)