### PR TITLE
feat: SwitchField button variant; rename toggle -> onoff

### DIFF
--- a/src/lib/shared/components/form/fields/SwitchField.svelte
+++ b/src/lib/shared/components/form/fields/SwitchField.svelte
@@ -15,15 +15,19 @@
     disabled?: boolean;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
-    /** Label shown in the `toggle` variant when unchecked (default "OFF"). */
+    /** Label shown in the `onoff` variant when unchecked (default "OFF"). */
     offLabel?: string;
     onChange?: (value: boolean) => void;
-    /** Label shown in the `toggle` variant when checked (default "ON"). */
+    /** Label shown in the `onoff` variant when checked (default "ON"). */
     onLabel?: string;
     optional?: boolean;
     schema?: ZodType;
-    /** `switch` is the sliding pill (default); `toggle` is the ON/OFF labelled style. */
-    variant?: 'switch' | 'toggle';
+    /**
+     * `switch` is the sliding pill (default); `onoff` is the ON/OFF labelled
+     * style; `button` is a `.btn` that is filled (`default`) when checked and
+     * outlined (`ghost`) when unchecked, using `children` as its label.
+     */
+    variant?: 'button' | 'onoff' | 'switch';
   }
 
   let {
@@ -55,11 +59,12 @@
 
   const attrs = $derived(view.attrs);
   const required = $derived(!optional);
+  const isChecked = $derived(attrs.checked as boolean);
 </script>
 
 <div class="form-switch-wrapper">
   <div class="form-switch-row">
-    {#if children}
+    {#if children && variant !== 'button'}
       <FieldLabel class="form-switch-label" for={attrs.name} {required}>
         {@render children()}
       </FieldLabel>
@@ -67,16 +72,22 @@
     <Switch.Root
       id={attrs.name}
       name={attrs.name}
-      class={variant === 'toggle' ? 'form-toggle' : 'form-switch'}
+      class={variant === 'onoff'
+        ? 'form-onoff'
+        : variant === 'button'
+          ? `btn form-switch-btn ${isChecked ? 'default' : 'ghost'}`
+          : 'form-switch'}
       aria-invalid={attrs['aria-invalid'] as 'false' | 'true' | boolean | undefined}
-      checked={attrs.checked as boolean}
+      checked={isChecked}
       {disabled}
       onCheckedChange={(v) => view.set(v === true)}
     >
-      {#if variant === 'toggle'}
-        <span class="form-toggle-text form-toggle-text--on">{onLabel}</span>
-        <span class="form-toggle-text form-toggle-text--off">{offLabel}</span>
-        <Switch.Thumb class="form-toggle-thumb" />
+      {#if variant === 'onoff'}
+        <span class="form-onoff-text form-onoff-text--on">{onLabel}</span>
+        <span class="form-onoff-text form-onoff-text--off">{offLabel}</span>
+        <Switch.Thumb class="form-onoff-thumb" />
+      {:else if variant === 'button'}
+        {@render children?.()}
       {:else}
         <Switch.Thumb class="form-switch-thumb" />
       {/if}

--- a/src/routes/fields/+page.svelte
+++ b/src/routes/fields/+page.svelte
@@ -431,27 +431,40 @@
           </Form>
           <Form
             class="mt-4 flex flex-col gap-4"
-            form={checkboxForm.for('toggle')}
+            form={checkboxForm.for('onoff')}
             schema={CheckboxSchema}
           >
-            <SwitchField name="agreed" form={checkboxForm.for('toggle')} variant="toggle">
+            <SwitchField name="agreed" form={checkboxForm.for('onoff')} variant="onoff">
               As an ON/OFF toggle
             </SwitchField>
-            <Button form={checkboxForm.for('toggle')}>Submit</Button>
+            <Button form={checkboxForm.for('onoff')}>Submit</Button>
+          </Form>
+          <Form
+            class="mt-4 flex flex-col gap-4"
+            form={checkboxForm.for('button')}
+            schema={CheckboxSchema}
+          >
+            <SwitchField name="agreed" form={checkboxForm.for('button')} variant="button">
+              As a button
+            </SwitchField>
+            <Button form={checkboxForm.for('button')}>Submit</Button>
           </Form>
           {@render standaloneLabel('bind:checked + onChange')}
           <CheckboxField name="agreed" onChange={(v) => (saChecked = v)} bind:checked={saChecked}>
             I agree
           </CheckboxField>
           <SwitchField name="enabled" bind:checked={saSwitch}>As a switch</SwitchField>
-          <SwitchField name="enabled" variant="toggle" bind:checked={saSwitch}>
+          <SwitchField name="enabled" variant="onoff" bind:checked={saSwitch}>
             As an ON/OFF toggle
+          </SwitchField>
+          <SwitchField name="enabled" variant="button" bind:checked={saSwitch}>
+            As a button
           </SwitchField>
           <SwitchField
             name="power"
             offLabel="NO"
             onLabel="YES"
-            variant="toggle"
+            variant="onoff"
             bind:checked={saSwitch}
           >
             Custom labels
@@ -462,10 +475,11 @@
           {`<CheckboxField name="agreed" form={remoteForm}>I agree to the terms</CheckboxField>
 <CheckboxField name="agreed" form={remoteForm} optional>Optional</CheckboxField>
 
-<!-- switch (default) vs ON/OFF toggle variant -->
+<!-- switch (default) vs onoff (ON/OFF labels) vs button (.btn) variants -->
 <SwitchField name="enabled" bind:checked>As a switch</SwitchField>
-<SwitchField name="enabled" variant="toggle" bind:checked>Toggle</SwitchField>
-<SwitchField name="power" variant="toggle" onLabel="YES" offLabel="NO" bind:checked>Custom</SwitchField>`}
+<SwitchField name="enabled" variant="onoff" bind:checked>Toggle</SwitchField>
+<SwitchField name="enabled" variant="button" bind:checked>As a button</SwitchField>
+<SwitchField name="power" variant="onoff" onLabel="YES" offLabel="NO" bind:checked>Custom</SwitchField>`}
         </CodeBlock>
       </Container>
 

--- a/src/template.css
+++ b/src/template.css
@@ -206,7 +206,7 @@
   transform: translateX(18px);
 }
 
-.form-toggle {
+.form-onoff {
   position: relative;
   display: inline-block;
   flex-shrink: 0;
@@ -220,20 +220,20 @@
   outline: none;
 }
 
-.form-toggle[data-state='checked'] {
+.form-onoff[data-state='checked'] {
   background: var(--tx);
 }
 
-.form-toggle[data-disabled] {
+.form-onoff[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.form-toggle:focus-visible {
+.form-onoff:focus-visible {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--tx) 15%, transparent);
 }
 
-.form-toggle-text {
+.form-onoff-text {
   position: absolute;
   top: 0;
   height: 100%;
@@ -248,27 +248,27 @@
   transition: opacity 0.15s ease;
 }
 
-.form-toggle-text--on {
+.form-onoff-text--on {
   left: 2px;
   color: var(--bg);
   opacity: 0;
 }
 
-.form-toggle-text--off {
+.form-onoff-text--off {
   right: 2px;
   color: var(--tx);
   opacity: 1;
 }
 
-.form-toggle[data-state='checked'] .form-toggle-text--on {
+.form-onoff[data-state='checked'] .form-onoff-text--on {
   opacity: 1;
 }
 
-.form-toggle[data-state='checked'] .form-toggle-text--off {
+.form-onoff[data-state='checked'] .form-onoff-text--off {
   opacity: 0;
 }
 
-.form-toggle-thumb {
+.form-onoff-thumb {
   position: absolute;
   top: 2px;
   left: 2px;
@@ -280,8 +280,17 @@
   pointer-events: none;
 }
 
-.form-toggle[data-state='checked'] .form-toggle-thumb {
+.form-onoff[data-state='checked'] .form-onoff-thumb {
   transform: translateX(28px);
+}
+
+/* `button` variant: reuses `.btn` (default when checked, ghost outline when not) */
+.form-switch-btn {
+  flex-shrink: 0;
+}
+
+.form-switch-btn:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tx) 15%, transparent);
 }
 
 .form-slider-wrapper {


### PR DESCRIPTION
## Summary
- Add a `button` variant to `SwitchField` that reuses the `.btn` classes (like `Button`): filled `default` when checked, outlined `ghost` when unchecked, using `children` as its label.
- Rename the existing ON/OFF labelled `toggle` variant to `onoff`.

## ⚠️ Breaking
`variant="toggle"` removed — consumers must switch to `variant="onoff"`.

## Changes
- `SwitchField.svelte`: `variant` is now `'button' | 'onoff' | 'switch'`; new `button` branch + `isChecked` derived.
- `template.css`: `.form-toggle*` → `.form-onoff*`; added `.form-switch-btn`.
- `routes/fields/+page.svelte`: demos + code sample updated, `button` examples added.

## Notes
This lib's form `Button` has no `outline` variant, so `ghost` (transparent + border) is used for the OFF look.

## Verification
`pnpm check` — fmt + eslint + svelte-check (0 errors) + 165 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)