### PR TITLE
fix(form): reset dirty to false on form reset event

### DIFF
--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -78,6 +78,9 @@
     dirty = true;
     onInput?.(event);
   }}
+  onreset={() => {
+    dirty = false;
+  }}
   use:applyEnctype
   {...remote.preflight(schema).enhance(async ({ form: formElement, submit }) => {
     try {


### PR DESCRIPTION
## Problem

`<button type="reset">` reverts form fields to their defaults, but `dirty` stayed `true` — out of sync with the form's actual state.

## Fix

Listen for the form `reset` event and set `dirty = false` ([Form.svelte](src/lib/shared/components/form/Form.svelte#L82-L84)).

The programmatic `formElement.reset()` on successful submit also fires this event, which is harmless — the `ok` branch already sets `dirty = false`.

## Verify

- `pnpm lint:svelte` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)