### PR TITLE
feat(form): custom Button variant + reset dirty on form reset

### DIFF
--- a/src/lib/shared/components/form/Button.svelte
+++ b/src/lib/shared/components/form/Button.svelte
@@ -6,7 +6,7 @@
   import Loader2 from '@lucide/svelte/icons/loader-2';
   import { Button as ButtonPrimitive } from 'bits-ui';
 
-  type Variant = 'default' | 'destructive' | 'ghost' | 'ghost-destructive';
+  type Variant = 'default' | 'destructive' | 'ghost' | 'ghost-destructive' | (string & {});
 
   interface Props extends Omit<HTMLButtonAttributes, 'form' | 'type'> {
     children?: Snippet;

--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -78,6 +78,9 @@
     dirty = true;
     onInput?.(event);
   }}
+  onreset={() => {
+    dirty = false;
+  }}
   use:applyEnctype
   {...remote.preflight(schema).enhance(async ({ form: formElement, submit }) => {
     try {


### PR DESCRIPTION
Combines two related form changes.

## 1. Reset `dirty` on form reset event

`<button type="reset">` reverted fields to defaults but left `dirty` stuck at `true`. Now listens for the form `reset` event and sets `dirty = false` ([Form.svelte](src/lib/shared/components/form/Form.svelte#L82-L84)). The programmatic `formElement.reset()` on successful submit also fires it — harmless, the `ok` branch already clears `dirty`.

## 2. Allow custom Button variant value

Widen Button `Variant` to `'default' | 'destructive' | 'ghost' | 'ghost-destructive' | (string & {})` ([Button.svelte](src/lib/shared/components/form/Button.svelte#L9)). `variant` is already interpolated as `.btn.{variant}`, so consumers just define a matching CSS rule. `(string & {})` keeps autocomplete for the known literals.

```svelte
<Button variant="success">Save</Button>
```
```css
.btn.success { /* consumer-defined */ }
```

## Verify

- `pnpm lint:svelte` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)