### PR TITLE
feat(form): custom-styled SelectField dropdown via bits-ui

### DIFF
--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -3,7 +3,9 @@
   import type { Component, Snippet } from 'svelte';
   import type { ZodType } from 'zod/v4';
 
+  import Check from '@lucide/svelte/icons/check';
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import { Select } from 'bits-ui';
 
   import { createFormView, createLocalSelectView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
@@ -72,15 +74,23 @@
   const valueToKey = $derived(
     new Map(items.map((item) => [String(getValue(item)), String(getKey(item))]))
   );
+  const keyToLabel = $derived(new Map(items.map((item) => [String(getKey(item)), getLabel(item)])));
+
+  // bits-ui `Select` uses this {value,label} list for typeahead + autofill matching.
+  const bitsItems = $derived(
+    items.map((item) => ({ label: getLabel(item), value: String(getKey(item)) }))
+  );
 
   // Form mode stores the submitted value string; standalone tracks the typed value,
-  // so the selected option is resolved from its key.
+  // so the selected option is resolved from its key. This string is both the value
+  // fed to bits-ui `Select` (its item values are keyed by `getKey`) and the value
+  // carried by the hidden input below into the form's FormData.
   const selectedValue = $derived(
     form ? (attrs.value as string) : (valueToKey.get(String(value ?? '')) ?? '')
   );
+  const selectedLabel = $derived(keyToLabel.get(selectedValue));
 
-  function handleChange(e: Event) {
-    const key = (e.currentTarget as HTMLSelectElement).value;
+  function handleChange(key: string) {
     const newValue = keyToValue.get(key) ?? '';
     const item = valueToItem.get(newValue);
     const typedValue = item === undefined ? undefined : getValue(item);
@@ -93,13 +103,15 @@
   {#if children}
     <FieldLabel for={attrs.name} {required}>{@render children()}</FieldLabel>
   {/if}
-  <div class={['form-select-wrapper', className].filter(Boolean).join(' ')}>
-    {#if Icon}
-      <div class="form-input-icon"><Icon /></div>
-    {/if}
-    <select
+  <Select.Root
+    allowDeselect={nullable}
+    items={bitsItems}
+    onValueChange={handleChange}
+    type="single"
+    value={selectedValue}
+  >
+    <Select.Trigger
       id={attrs.name}
-      name={attrs.name}
       class={[
         'form-input',
         'form-select',
@@ -109,17 +121,40 @@
         .filter(Boolean)
         .join(' ')}
       aria-invalid={attrs['aria-invalid'] as 'false' | 'true' | boolean | undefined}
-      onchange={handleChange}
-      {required}
-      value={selectedValue}
     >
-      <option disabled={!nullable} value="">{displayPlaceholder}</option>
-      {#each items as item (getKey(item))}
-        <option value={String(getKey(item))}>{getLabel(item)}</option>
-      {/each}
-    </select>
-    <ChevronDown class="form-select-chevron" size={14} />
-  </div>
+      {#if Icon}
+        <div class="form-input-icon"><Icon /></div>
+      {/if}
+      <span class="form-select-value">{selectedLabel ?? displayPlaceholder}</span>
+      <ChevronDown class="form-select-chevron" size={14} />
+    </Select.Trigger>
+    <Select.Portal>
+      <Select.Content
+        class={['form-select-menu', className].filter(Boolean).join(' ')}
+        sideOffset={4}
+      >
+        <Select.Viewport>
+          {#each items as item (getKey(item))}
+            <Select.Item
+              class="form-select-item"
+              label={getLabel(item)}
+              value={String(getKey(item))}
+            >
+              {#snippet children({ selected })}
+                <span class="form-select-item-label">{getLabel(item)}</span>
+                {#if selected}
+                  <Check class="form-select-item-check" size={14} />
+                {/if}
+              {/snippet}
+            </Select.Item>
+          {/each}
+        </Select.Viewport>
+      </Select.Content>
+    </Select.Portal>
+  </Select.Root>
+  <!-- bits-ui `Select` has no native form control; this hidden input carries the
+       selected value into FormData exactly as the old native <select name> did. -->
+  <input name={attrs.name} type="hidden" value={selectedValue} />
   {#each view.issues() as issue (`${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}

--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -107,6 +107,7 @@
     allowDeselect={nullable}
     items={bitsItems}
     onValueChange={handleChange}
+    {required}
     type="single"
     value={selectedValue}
   >
@@ -116,7 +117,8 @@
         'form-input',
         'form-select',
         Icon && 'form-input--with-icon',
-        !selectedValue && 'form-select--placeholder'
+        !selectedValue && 'form-select--placeholder',
+        className
       ]
         .filter(Boolean)
         .join(' ')}
@@ -129,10 +131,7 @@
       <ChevronDown class="form-select-chevron" size={14} />
     </Select.Trigger>
     <Select.Portal>
-      <Select.Content
-        class={['form-select-menu', className].filter(Boolean).join(' ')}
-        sideOffset={4}
-      >
+      <Select.Content class="form-select-menu" sideOffset={4}>
         <Select.Viewport>
           {#each items as item (getKey(item))}
             <Select.Item

--- a/src/template.css
+++ b/src/template.css
@@ -797,7 +797,7 @@
 
 /* bits-ui marks the keyboard/pointer-highlighted item via data-highlighted. */
 .form-select-item[data-highlighted] {
-  background: var(--bd);
+  background: var(--sf);
 }
 
 .form-select-item[data-disabled] {

--- a/src/template.css
+++ b/src/template.css
@@ -720,30 +720,89 @@
 
 /* ─── Select (form-select) ─────────────────────────────────────────────────── */
 
-.form-select-wrapper {
-  position: relative;
-}
-
+/* The trigger is a bits-ui <button>, not a native <select>: lay its content out
+   as [icon] [value …grows] [chevron] and keep the .form-input box styling. */
 .form-select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  padding-right: 32px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-right: 10px;
+  text-align: left;
   cursor: pointer;
-  background-image: none;
 }
 
-.form-select--placeholder {
+.form-select-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.form-select--placeholder .form-select-value {
   color: var(--txs);
 }
 
 .form-select-chevron {
+  flex: none;
   pointer-events: none;
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   color: var(--txs);
+  transition: transform 0.12s ease;
+}
+
+.form-select[data-state='open'] .form-select-chevron {
+  transform: rotate(180deg);
+}
+
+/* Custom dropdown panel (replaces the OS-rendered <option> list). */
+.form-select-menu {
+  z-index: 60;
+  min-width: var(--bits-floating-anchor-width);
+  max-height: min(300px, var(--bits-floating-available-height));
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--bg);
+  border: 1px solid var(--bd);
+  border-radius: 2px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
+  box-sizing: border-box;
+}
+
+.form-select-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  height: 30px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: var(--tx);
+  border-radius: 2px;
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+}
+
+.form-select-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.form-select-item-check {
+  flex: none;
+  color: var(--tx);
+}
+
+/* bits-ui marks the keyboard/pointer-highlighted item via data-highlighted. */
+.form-select-item[data-highlighted] {
+  background: var(--bd);
+}
+
+.form-select-item[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* ─── Date range ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Why

`SelectField` rendered a native `<select>`, whose open option list is drawn by the OS/browser — **not stylable via CSS**. Only the closed box + chevron could be themed, so the dropdown never matched the app UI.

## What

- Replace the native `<select>` with a **bits-ui `Select`** (already a dependency; matches the repo's "use bits-ui/shadcn" guideline): a styled trigger button + a floating panel of `div` items, fully CSS-controllable.
- **Public API unchanged** — `getKey`/`getValue`/`getLabel`/`items`/`placeholder`/`icon`/`nullable`/`optional`/`onchange`/`value`/`schema`, plus both the `form` and standalone paths. Consumers need no changes.
- **Form submission preserved**: a hidden `<input name value>` carries the selected value into `FormData` exactly as the old `<select name>` did; selection changes still flow through `view.set()` → `field.set()`.
- **`template.css`**: reworked the `.form-select*` block for the button trigger and added `.form-select-menu` / `.form-select-item` (hover/selected/disabled) styles built on the existing design tokens (`--bg`/`--bd`/`--tx`/`--txs`), so the panel matches the rest of the UI in light **and** dark.

## Verification

- `pnpm lint:svelte` — 0 errors
- `pnpm lint:es` — 0 errors
- `pnpm test` — 171 passed
- Dev server `/fields` demo: SSR renders triggers with placeholder, hidden form inputs wired, no runtime/hydration errors. Interactive open/select handled by bits-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)