### PR TITLE
fix(form): flag dirty + re-validate on programmatic field changes

### DIFF
--- a/src/lib/shared/components/form/Form.svelte
+++ b/src/lib/shared/components/form/Form.svelte
@@ -12,6 +12,8 @@
 
   import { toast } from 'svelte-sonner';
 
+  import { setFormChangeListener } from './field-view.svelte.js';
+
   // Accepts both a plain remote form and a `.for(id)` instance (which omits `for`).
   type AnyRemoteForm =
     | Omit<RemoteForm<Input, FormResult<Data>>, 'for'>
@@ -55,6 +57,14 @@
   if (defaults !== undefined) {
     remote.fields.set(defaults);
   }
+
+  // bits-ui fields (Switch/Slider/Select) change value via `view.set()` without a
+  // bubbling DOM `input` event, so the `oninput` handler below never sees them.
+  // They notify through this listener instead — same re-validate + dirty as typing.
+  setFormChangeListener(() => {
+    remote.validate();
+    dirty = true;
+  });
 
   // Only render hidden inputs whose value is set — `as('hidden', value)` throws on
   // null/undefined/empty string. Derived so value changes on `hidden` propagate.

--- a/src/lib/shared/components/form/field-view.svelte.ts
+++ b/src/lib/shared/components/form/field-view.svelte.ts
@@ -1,8 +1,25 @@
 import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
 import type { ZodType } from 'zod/v4';
 
+import { getContext, setContext } from 'svelte';
+
 /** Normalised validation issue shape consumed by every field template. */
 export type FieldIssue = { message: string; path: Array<number | string> };
+
+/**
+ * Bridge between a form-bound field and its enclosing `<Form>`. Native inputs
+ * bubble a DOM `input` event that `<Form>` listens for (to re-validate + mark
+ * dirty), but bits-ui controls (`Switch`, `Slider`, `Select`) update their value
+ * programmatically via `view.set()` and emit no such event — so `<Form>` would
+ * never learn they changed. `<Form>` registers a listener here and every
+ * `createFormView().set` calls it, so those fields flag dirty + validate too.
+ */
+const FORM_CHANGE_KEY = Symbol('web-svelte:form-change');
+
+/** Called by `<Form>` during init to receive programmatic field-change notifications. */
+export function setFormChangeListener(listener: () => void): void {
+  setContext(FORM_CHANGE_KEY, listener);
+}
 
 /**
  * The surface every field template consumes. Produced either from a `RemoteForm`
@@ -33,12 +50,18 @@ export function createFormView<Input extends RemoteFormInput>(
 ): FieldView {
   const field = $derived((form.fields as Record<string, LooseFormField>)[name]);
   const attrs = $derived(field.as(type, ...asArgs));
+  // Read once at init (getContext requirement). Undefined when the field is used
+  // outside a `<Form>`, in which case a programmatic set simply notifies no one.
+  const notifyChange = getContext<(() => void) | undefined>(FORM_CHANGE_KEY);
   return {
     get attrs() {
       return attrs;
     },
     issues: () => field.issues() ?? [],
-    set: (value) => field.set(value)
+    set: (value) => {
+      field.set(value);
+      notifyChange?.();
+    }
   };
 }
 


### PR DESCRIPTION
## Problem

`<Form>` tracks `dirty` (and triggers live re-validation) via a native `oninput` handler on the `<form>` element. That works for real `<input>`-backed fields, which bubble a DOM `input` event.

But the bits-ui-backed fields — **`SwitchField`, `SliderField`, `SelectField`** — update their value programmatically through `view.set()` from bits-ui callbacks (`onCheckedChange` / `onValueChange`). Those emit **no bubbling `input` event**, so `<Form>`'s `oninput` never fires for them:

- `bind:dirty` stays `false` when the user only toggles switches / drags a slider / picks a select option → an "Unsaved changes" indicator never shows.
- Live schema re-validation (`remote.validate()`) doesn't run on those changes either.

Repro: a form whose only fields are `SwitchField`s — toggling them leaves `dirty === false`.

## Fix

A small context bridge between a form-bound field and its enclosing `<Form>`:

- `field-view.svelte.ts` exposes `setFormChangeListener(fn)` (context setter). Every `createFormView().set()` calls the registered listener after `field.set()`.
- `<Form>` registers a listener that mirrors its existing `oninput` path: `remote.validate(); dirty = true`.

Native inputs are unaffected — they still bubble `input` as before (the two paths are idempotent). A field rendered outside a `<Form>` finds no listener in context and notifies no one.

Centralizing in `createFormView` means every current and future bits-ui field is covered without per-field wiring.

## Verify

- `pnpm check` — prettier, eslint, `svelte-check` (0 errors), 171 unit tests pass.
- Manual: a `<Form bind:dirty>` containing only `SwitchField`s now flips `dirty` on toggle; the same for `SliderField` / `SelectField`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)