### PR TITLE
feat(form): calendar-based DateRangeField picker

### DIFF
--- a/src/lib/shared/components/form/fields/DateRangeField.svelte
+++ b/src/lib/shared/components/form/fields/DateRangeField.svelte
@@ -96,7 +96,7 @@
   let localRange: DateRange = $state({ end: undefined, start: undefined });
 
   $effect(() => {
-    if (open) localRange = calendarValue;
+    if (!open) localRange = calendarValue;
   });
 
   function handleRangeChange(range: DateRange) {
@@ -139,7 +139,7 @@
           weekdayFormat="short"
         >
           {#snippet children({ months, weekdays })}
-            {#each months as month (month.value)}
+            {#each months as month (month.value.toString())}
               <div class="form-daterange-header">
                 <RangeCalendar.PrevButton class="form-daterange-nav">
                   <ChevronLeft size={14} />
@@ -160,9 +160,9 @@
                   </RangeCalendar.GridRow>
                 </RangeCalendar.GridHead>
                 <RangeCalendar.GridBody>
-                  {#each month.weeks as weekDates (weekDates)}
+                  {#each month.weeks as weekDates (weekDates[0].toString())}
                     <RangeCalendar.GridRow class="form-daterange-row">
-                      {#each weekDates as date (date)}
+                      {#each weekDates as date (date.toString())}
                         <RangeCalendar.Cell class="form-daterange-cell" {date} month={month.value}>
                           <RangeCalendar.Day class="form-daterange-day" />
                         </RangeCalendar.Cell>

--- a/src/lib/shared/components/form/fields/DateRangeField.svelte
+++ b/src/lib/shared/components/form/fields/DateRangeField.svelte
@@ -1,9 +1,17 @@
 <script generics="Input extends RemoteFormInput" lang="ts">
+  import type { CalendarDate } from '@internationalized/date';
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
   import type { ZodType } from 'zod/v4';
 
-  import { createFormView, createLocalTextView, type FieldView } from '../field-view.svelte.js';
+  import { type DateValue, parseDate } from '@internationalized/date';
+  import Calendar from '@lucide/svelte/icons/calendar';
+  import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+  import ChevronRight from '@lucide/svelte/icons/chevron-right';
+  import { type DateRange, Popover, RangeCalendar } from 'bits-ui';
+
+  import { formatDateFull } from '../../../utils/datetime/index.js';
+  import { createFormView, createLocalSelectView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
 
   interface Props {
@@ -36,20 +44,18 @@
   // svelte-ignore state_referenced_locally
   const startView: FieldView = form
     ? createFormView(form, startName, 'date')
-    : createLocalTextView<string>({
+    : createLocalSelectView<string>({
         get: () => startValue,
         name: startName,
-        onInput: () => onChange?.({ end: endValue, start: startValue }),
         schema: startSchema,
         write: (v) => (startValue = v)
       });
   // svelte-ignore state_referenced_locally
   const endView: FieldView = form
     ? createFormView(form, endName, 'date')
-    : createLocalTextView<string>({
+    : createLocalSelectView<string>({
         get: () => endValue,
         name: endName,
-        onInput: () => onChange?.({ end: endValue, start: startValue }),
         schema: endSchema,
         write: (v) => (endValue = v)
       });
@@ -57,23 +63,122 @@
   const required = $derived(!optional);
   const startAttrs = $derived(startView.attrs);
   const endAttrs = $derived(endView.attrs);
+
+  let open = $state(false);
+
+  function toDateValue(iso: unknown): DateValue | undefined {
+    if (typeof iso !== 'string' || !iso) return undefined;
+    try {
+      return parseDate(iso);
+    } catch {
+      return undefined;
+    }
+  }
+
+  function toIso(date: DateValue | undefined): string {
+    return date ? date.toString() : '';
+  }
+
+  const calendarValue: DateRange = $derived({
+    end: toDateValue(endAttrs.value),
+    start: toDateValue(startAttrs.value)
+  });
+
+  const displayLabel = $derived(
+    calendarValue.start && calendarValue.end
+      ? `${formatDateFull(calendarValue.start as CalendarDate)} – ${formatDateFull(calendarValue.end as CalendarDate)}`
+      : 'Select date range'
+  );
+
+  // Scratch copy the calendar edits freely while the range is incomplete, so
+  // picking a start day doesn't blank/validate the committed end field. Only
+  // a complete range gets written back via `.set()`.
+  let localRange: DateRange = $state({ end: undefined, start: undefined });
+
+  $effect(() => {
+    if (open) localRange = calendarValue;
+  });
+
+  function handleRangeChange(range: DateRange) {
+    localRange = range;
+    if (!range.start || !range.end) return;
+
+    const startIso = toIso(range.start);
+    const endIso = toIso(range.end);
+    startView.set(startIso);
+    endView.set(endIso);
+    onChange?.({ end: endIso, start: startIso });
+    open = false;
+  }
 </script>
 
 <div class="form-field">
   {#if children}
     <FieldLabel for={startAttrs.name} {required}>{@render children()}</FieldLabel>
   {/if}
-  <div class="form-date-range">
-    <input
+  <Popover.Root bind:open>
+    <Popover.Trigger
       id={startAttrs.name}
-      class="form-date-range-input"
-      {required}
-      type="date"
-      {...startAttrs}
-    />
-    <span class="form-date-range-sep" aria-hidden="true">–</span>
-    <input id={endAttrs.name} class="form-date-range-input" {required} type="date" {...endAttrs} />
-  </div>
+      class={[
+        'form-input',
+        'form-select',
+        'form-input--with-icon',
+        !(calendarValue.start && calendarValue.end) && 'form-select--placeholder'
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div class="form-input-icon"><Calendar size={14} /></div>
+      <span class="form-select-value">{displayLabel}</span>
+    </Popover.Trigger>
+    <Popover.Portal>
+      <Popover.Content class="form-daterange-menu" sideOffset={4}>
+        <RangeCalendar.Root
+          onValueChange={handleRangeChange}
+          value={localRange}
+          weekdayFormat="short"
+        >
+          {#snippet children({ months, weekdays })}
+            {#each months as month (month.value)}
+              <div class="form-daterange-header">
+                <RangeCalendar.PrevButton class="form-daterange-nav">
+                  <ChevronLeft size={14} />
+                </RangeCalendar.PrevButton>
+                <RangeCalendar.Heading class="form-daterange-heading" />
+                <RangeCalendar.NextButton class="form-daterange-nav">
+                  <ChevronRight size={14} />
+                </RangeCalendar.NextButton>
+              </div>
+              <RangeCalendar.Grid class="form-daterange-grid">
+                <RangeCalendar.GridHead>
+                  <RangeCalendar.GridRow class="form-daterange-row">
+                    {#each weekdays as weekday (weekday)}
+                      <RangeCalendar.HeadCell class="form-daterange-headcell">
+                        {weekday.slice(0, 2)}
+                      </RangeCalendar.HeadCell>
+                    {/each}
+                  </RangeCalendar.GridRow>
+                </RangeCalendar.GridHead>
+                <RangeCalendar.GridBody>
+                  {#each month.weeks as weekDates (weekDates)}
+                    <RangeCalendar.GridRow class="form-daterange-row">
+                      {#each weekDates as date (date)}
+                        <RangeCalendar.Cell class="form-daterange-cell" {date} month={month.value}>
+                          <RangeCalendar.Day class="form-daterange-day" />
+                        </RangeCalendar.Cell>
+                      {/each}
+                    </RangeCalendar.GridRow>
+                  {/each}
+                </RangeCalendar.GridBody>
+              </RangeCalendar.Grid>
+            {/each}
+          {/snippet}
+        </RangeCalendar.Root>
+      </Popover.Content>
+    </Popover.Portal>
+  </Popover.Root>
+  <input name={startAttrs.name} type="hidden" value={startAttrs.value} />
+  <input name={endAttrs.name} type="hidden" value={endAttrs.value} />
   {#each startView.issues() as issue (`start-${issue.path}`)}
     <p class="form-error">{issue.message}</p>
   {/each}

--- a/src/template.css
+++ b/src/template.css
@@ -807,47 +807,121 @@
 
 /* ─── Date range ────────────────────────────────────────────────────────────── */
 
-.form-date-range {
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  height: 35px;
-  padding: 0 12px;
+/* Popover panel hosting the range calendar. */
+.form-daterange-menu {
+  z-index: 60;
+  padding: 12px;
   background: var(--bg);
   border: 1px solid var(--bd);
   border-radius: 2px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
   box-sizing: border-box;
-  transition: border-color 0.12s ease;
 }
 
-.form-date-range:focus-within {
-  border-color: var(--tx);
+.form-daterange-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
 }
 
-.form-date-range-input {
-  width: 110px;
-  flex-shrink: 0;
-  height: 100%;
-  padding: 0;
-  font-family: inherit;
+.form-daterange-heading {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--tx);
+}
+
+.form-daterange-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--txs);
+  background: transparent;
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.form-daterange-nav:hover {
+  color: var(--tx);
+  background: var(--sf);
+}
+
+.form-daterange-nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.form-daterange-grid {
+  border-collapse: collapse;
+}
+
+.form-daterange-headcell {
+  width: 32px;
+  padding: 4px 0;
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--txs);
+  text-align: center;
+}
+
+.form-daterange-cell {
+  padding: 1px;
+  text-align: center;
+}
+
+/* Range endpoints and the highlighted span between them are driven by bits-ui's
+   data-range-start/-end/-middle attributes on this element. */
+.form-daterange-day {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
   font-size: 12px;
   color: var(--tx);
   background: transparent;
-  border: none;
-  outline: none;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.1s ease;
 }
 
-.form-date-range-input:focus,
-.form-date-range-input:focus-visible {
-  outline: none;
-  box-shadow: none;
+.form-daterange-day:hover {
+  background: var(--sf);
 }
 
-.form-date-range-sep {
-  flex-shrink: 0;
-  padding: 0 6px;
+.form-daterange-day[data-today] {
+  font-weight: 700;
+}
+
+.form-daterange-day[data-outside-month] {
   color: var(--txs);
-  font-size: 12px;
+  opacity: 0.5;
+}
+
+.form-daterange-day[data-disabled],
+.form-daterange-day[data-unavailable] {
+  cursor: not-allowed;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.form-daterange-day[data-range-middle] {
+  background: var(--sf);
+}
+
+.form-daterange-day[data-range-start],
+.form-daterange-day[data-range-end] {
+  color: var(--bg);
+  background: var(--tx);
+}
+
+.form-daterange-day[data-focused] {
+  outline: 2px solid var(--tx);
+  outline-offset: -2px;
 }
 
 /* ─── File ──────────────────────────────────────────────────────────────────── */

--- a/src/template.css
+++ b/src/template.css
@@ -906,7 +906,6 @@
 .form-daterange-day[data-unavailable] {
   cursor: not-allowed;
   opacity: 0.35;
-  pointer-events: none;
 }
 
 .form-daterange-day[data-range-middle] {


### PR DESCRIPTION
## Summary

`DateRangeField` was two plain `<input type="date">` boxes side by side — each one popping the browser's own native date picker independently, with no shared calendar view. This replaces it with a single popover calendar (bits-ui `RangeCalendar`): click a start day, then an end day, and the popover closes automatically.

- Props/behavior are unchanged: `startName`/`endName`/`startValue`/`endValue`/`onChange`/`form`/schemas all work exactly as before, so both the form-mode and standalone (`bind:startValue`/`bind:endValue`) usages upgrade with **no call-site changes**.
- The trigger button shows a formatted range ("10 Jul 2026 – 20 Jul 2026") or a placeholder, matching the existing `SelectField` trigger's visual style (`.form-input`/`.form-select` classes).
- New `.form-daterange-*` classes added to `template.css`, replacing the now-unused `.form-date-range*` classes.
- Calendar selection is kept in local scratch state until the range is complete, so picking only a start day doesn't blank/validate the (still-empty) end field.

## Test plan

- [x] `pnpm lint:es`, `pnpm lint:svelte`, `pnpm test`, `pnpm build:lib` all pass
- [x] Manually drove the `/fields` demo page with Playwright (both the form-mode and standalone `DateRangeField` instances): trigger opens the popover, picking a start day keeps it open, prev/next month navigation works without closing it, picking an end day highlights the range, closes the popover, and updates the trigger label + bound values correctly. Zero console errors.