### PR TITLE
feat(form): passthrough native input attrs on TextField/NumberField/EmailField

### DIFF
--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -32,7 +32,7 @@
     /** Standalone only — fired on every keystroke. */
     onInput?: (value: T) => void;
     /** Raw native keydown — passed through to the underlying <input> (e.g. Enter-to-submit). */
-    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
+    onkeydown?: HTMLInputAttributes['onkeydown'];
     optional?: boolean;
     placeholder?: string;
     /** Standalone only — optional per-field validation. */

--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -1,6 +1,7 @@
 <script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { HTMLInputAttributes } from 'svelte/elements';
   import type { ZodType } from 'zod/v4';
 
   import UiInput from '$lib/shared/components/ui/Input.svelte';
@@ -9,34 +10,58 @@
   import FieldLabel from './FieldLabel.svelte';
 
   interface Props {
+    /** Native autocapitalize hint — passed through to the underlying <input>. */
+    autocapitalize?: HTMLInputAttributes['autocapitalize'];
+    /** Native autocomplete hint — passed through to the underlying <input>. */
+    autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
+    /** Extra class(es) merged onto the underlying <input> (in addition to `form-input`). */
+    class?: string;
     /** When omitted the field is standalone — controlled via `bind:value`. */
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
+    /** Mobile keyboard hint (e.g. 'numeric', 'decimal') — passed through to the underlying <input>. */
+    inputmode?: HTMLInputAttributes['inputmode'];
+    /** `type="number"` upper bound — passed through to the underlying <input>. */
+    max?: HTMLInputAttributes['max'];
+    /** `type="number"` lower bound — passed through to the underlying <input>. */
+    min?: HTMLInputAttributes['min'];
     name: keyof Input & string;
     /** Standalone only — fired on the native `change` event. */
     onChange?: (value: T) => void;
     /** Standalone only — fired on every keystroke. */
     onInput?: (value: T) => void;
+    /** Raw native keydown — passed through to the underlying <input> (e.g. Enter-to-submit). */
+    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
     optional?: boolean;
     placeholder?: string;
     /** Standalone only — optional per-field validation. */
     schema?: ZodType;
+    /** Native spellcheck hint — passed through to the underlying <input>. */
+    spellcheck?: HTMLInputAttributes['spellcheck'];
     type: string;
     /** Standalone only — bound value when no `form` is provided. */
     value?: T;
   }
 
   let {
+    autocapitalize,
+    autocomplete,
     children,
+    class: className,
     form,
     icon,
+    inputmode,
+    max,
+    min,
     name,
     onChange,
     onInput,
+    onkeydown,
     optional,
     placeholder,
     schema,
+    spellcheck,
     type,
     value = $bindable()
   }: Props = $props();
@@ -71,9 +96,17 @@
   {/if}
   <UiInput
     id={view.attrs.name}
+    class={className}
+    {autocapitalize}
+    {autocomplete}
     {icon}
+    {inputmode}
+    {max}
+    {min}
+    {onkeydown}
     placeholder={displayPlaceholder}
     {required}
+    {spellcheck}
     {type}
     {...view.attrs}
   />

--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -22,10 +22,6 @@
     icon?: Component;
     /** Mobile keyboard hint (e.g. 'numeric', 'decimal') — passed through to the underlying <input>. */
     inputmode?: HTMLInputAttributes['inputmode'];
-    /** `type="number"` upper bound — passed through to the underlying <input>. */
-    max?: HTMLInputAttributes['max'];
-    /** `type="number"` lower bound — passed through to the underlying <input>. */
-    min?: HTMLInputAttributes['min'];
     name: keyof Input & string;
     /** Standalone only — fired on the native `change` event. */
     onChange?: (value: T) => void;
@@ -52,8 +48,6 @@
     form,
     icon,
     inputmode,
-    max,
-    min,
     name,
     onChange,
     onInput,
@@ -101,8 +95,6 @@
     {autocomplete}
     {icon}
     {inputmode}
-    {max}
-    {min}
     {onkeydown}
     placeholder={displayPlaceholder}
     {required}

--- a/src/lib/shared/components/form/fields/EmailField.svelte
+++ b/src/lib/shared/components/form/fields/EmailField.svelte
@@ -15,7 +15,7 @@
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
-    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
+    onkeydown?: HTMLInputAttributes['onkeydown'];
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;

--- a/src/lib/shared/components/form/fields/EmailField.svelte
+++ b/src/lib/shared/components/form/fields/EmailField.svelte
@@ -1,44 +1,60 @@
 <script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Snippet } from 'svelte';
+  import type { HTMLInputAttributes } from 'svelte/elements';
   import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
+    autocapitalize?: HTMLInputAttributes['autocapitalize'];
+    autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
+    class?: string;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
+    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;
+    spellcheck?: HTMLInputAttributes['spellcheck'];
     value?: T;
   }
 
   let {
+    autocapitalize,
+    autocomplete,
     children,
+    class: className,
     form,
     name,
     onChange,
     onInput,
+    onkeydown,
     optional,
     placeholder,
     schema,
+    spellcheck,
     value = $bindable()
   }: Props = $props();
 </script>
 
 <Field
   {name}
+  class={className}
+  {autocapitalize}
+  {autocomplete}
   {children}
   {form}
   {onChange}
   {onInput}
+  {onkeydown}
   {optional}
   {placeholder}
   {schema}
+  {spellcheck}
   type="email"
   bind:value
 />

--- a/src/lib/shared/components/form/fields/NumberField.svelte
+++ b/src/lib/shared/components/form/fields/NumberField.svelte
@@ -1,17 +1,25 @@
 <script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { HTMLInputAttributes } from 'svelte/elements';
   import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
+    autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
+    class?: string;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
+    /** Mobile keyboard hint — e.g. 'numeric' to avoid the native spinner while keeping the numeric pad. */
+    inputmode?: HTMLInputAttributes['inputmode'];
+    max?: HTMLInputAttributes['max'];
+    min?: HTMLInputAttributes['min'];
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
+    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;
@@ -19,12 +27,18 @@
   }
 
   let {
+    autocomplete,
     children,
+    class: className,
     form,
     icon,
+    inputmode,
+    max,
+    min,
     name,
     onChange,
     onInput,
+    onkeydown,
     optional,
     placeholder,
     schema,
@@ -34,11 +48,17 @@
 
 <Field
   {name}
+  class={className}
+  {autocomplete}
   {children}
   {form}
   {icon}
+  {inputmode}
+  {max}
+  {min}
   {onChange}
   {onInput}
+  {onkeydown}
   {optional}
   {placeholder}
   {schema}

--- a/src/lib/shared/components/form/fields/NumberField.svelte
+++ b/src/lib/shared/components/form/fields/NumberField.svelte
@@ -19,7 +19,7 @@
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
-    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
+    onkeydown?: HTMLInputAttributes['onkeydown'];
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;

--- a/src/lib/shared/components/form/fields/NumberField.svelte
+++ b/src/lib/shared/components/form/fields/NumberField.svelte
@@ -14,8 +14,6 @@
     icon?: Component;
     /** Mobile keyboard hint — e.g. 'numeric' to avoid the native spinner while keeping the numeric pad. */
     inputmode?: HTMLInputAttributes['inputmode'];
-    max?: HTMLInputAttributes['max'];
-    min?: HTMLInputAttributes['min'];
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
@@ -33,8 +31,6 @@
     form,
     icon,
     inputmode,
-    max,
-    min,
     name,
     onChange,
     onInput,
@@ -54,8 +50,6 @@
   {form}
   {icon}
   {inputmode}
-  {max}
-  {min}
   {onChange}
   {onInput}
   {onkeydown}

--- a/src/lib/shared/components/form/fields/TextField.svelte
+++ b/src/lib/shared/components/form/fields/TextField.svelte
@@ -1,47 +1,69 @@
 <script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
   import type { ZodType } from 'zod/v4';
 
   import Field from '../Field.svelte';
 
   interface Props {
+    autocapitalize?: HTMLInputAttributes['autocapitalize'];
+    autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
+    class?: string;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
+    inputmode?: HTMLInputAttributes['inputmode'];
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
+    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;
+    spellcheck?: HTMLInputAttributes['spellcheck'];
+    /** Defaults to 'text' — override for a text-like native type (e.g. 'tel', 'url'). */
+    type?: Extract<HTMLInputTypeAttribute, 'tel' | 'text' | 'url'>;
     value?: T;
   }
 
   let {
+    autocapitalize,
+    autocomplete,
     children,
+    class: className,
     form,
     icon,
+    inputmode,
     name,
     onChange,
     onInput,
+    onkeydown,
     optional,
     placeholder,
     schema,
+    spellcheck,
+    type = 'text',
     value = $bindable()
   }: Props = $props();
 </script>
 
 <Field
   {name}
+  class={className}
+  {autocapitalize}
+  {autocomplete}
   {children}
   {form}
   {icon}
+  {inputmode}
   {onChange}
   {onInput}
+  {onkeydown}
   {optional}
   {placeholder}
   {schema}
-  type="text"
+  {spellcheck}
+  {type}
   bind:value
 />

--- a/src/lib/shared/components/form/fields/TextField.svelte
+++ b/src/lib/shared/components/form/fields/TextField.svelte
@@ -17,13 +17,13 @@
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
-    onkeydown?: (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => void;
+    onkeydown?: HTMLInputAttributes['onkeydown'];
     optional?: boolean;
     placeholder?: string;
     schema?: ZodType;
     spellcheck?: HTMLInputAttributes['spellcheck'];
-    /** Defaults to 'text' — override for a text-like native type (e.g. 'tel', 'url'). */
-    type?: Extract<HTMLInputTypeAttribute, 'tel' | 'text' | 'url'>;
+    /** Defaults to 'text' — override for a text-like native type (e.g. 'search', 'tel', 'url'). */
+    type?: Extract<HTMLInputTypeAttribute, 'search' | 'tel' | 'text' | 'url'>;
     value?: T;
   }
 


### PR DESCRIPTION
## Summary
- `TextField`/`NumberField`/`EmailField` had a fixed prop list that never reached common native `<input>` attributes, even though `UiInput` already forwards `...rest` internally — `Field.svelte` was the layer that swallowed them.
- Adds explicit passthrough props (`class`, `autocomplete`, `autocapitalize`, `spellcheck`, `inputmode`, `onkeydown`) threaded through `Field.svelte` → `UiInput`.
- `NumberField` additionally gets `min`/`max`.
- `TextField` additionally gets an optional `type` override (`'text' | 'tel' | 'url'`, default `'text'`) for text-like non-text input types.

Driven by a real migration: converting a batch of hand-rolled `<input>` pages to these field components lost mobile numeric keyboards (`inputmode`), Enter-to-submit (`onkeydown`), and number bounds (`min`/`max`) since there was no way to pass them through.

## Test plan
- [x] `pnpm lint:es` — 0 errors
- [x] `pnpm lint:svelte` (svelte-check) — 0 errors/warnings
- [x] `pnpm test` — 171 passed
- [x] `pnpm build:lib` (svelte-package + publint) — builds clean, regenerated `.d.ts` includes the new props
- [x] `pnpm fmt`