### PR TITLE
fix(ci): pin undici to 7.24.8 to fix release asset upload

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ catalogs:
       version: 4.3.6
 
 overrides:
-  undici: 7.24.8
+  '@semantic-release/github>undici': 7.24.8
 
 importers:
 
@@ -3337,6 +3337,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
@@ -3654,7 +3658,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.24.8
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -6587,6 +6591,8 @@ snapshots:
     optional: true
 
   undici-types@7.19.2: {}
+
+  undici@6.27.0: {}
 
   undici@7.24.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ catalogs:
       specifier: ^4.3.6
       version: 4.3.6
 
+overrides:
+  undici: 7.24.8
+
 importers:
 
   .:
@@ -3334,16 +3337,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
-    engines: {node: '>=18.17'}
-
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3659,7 +3654,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 7.24.8
 
   '@actions/io@3.0.2': {}
 
@@ -4272,7 +4267,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.16
-      undici: 7.25.0
+      undici: 7.24.8
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6593,11 +6588,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@6.25.0: {}
-
   undici@7.24.8: {}
-
-  undici@7.25.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - '.'
+overrides:
+  # 7.25.0 throws "invalid content-length header" during the release asset
+  # upload (@semantic-release/github -> @octokit/request), failing every Release run.
+  undici: 7.24.8
 catalog:
   '@internationalized/date': ^3.12.1
   '@sveltejs/kit': ^2.57.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,11 @@
 packages:
   - '.'
 overrides:
-  # 7.25.0 throws "invalid content-length header" during the release asset
-  # upload (@semantic-release/github -> @octokit/request), failing every Release run.
-  undici: 7.24.8
+  # @semantic-release/github pulls undici@7.25.0, which throws "invalid
+  # content-length header" during the release asset upload, failing every
+  # Release run. Scoped to that one edge so @actions/http-client keeps its
+  # own undici@6 line untouched.
+  '@semantic-release/github>undici': 7.24.8
 catalog:
   '@internationalized/date': ^3.12.1
   '@sveltejs/kit': ^2.57.1


### PR DESCRIPTION
## Summary
- Every Release run since v4.9.1 fails on the `@semantic-release/github` publish step: `InvalidArgumentError: invalid content-length header` while uploading the tarball asset via `@octokit/request`.
- npm publish succeeds first, so packages keep shipping to the registry fine — but the GitHub release stays a broken empty draft (no tag body notes visible, no asset) and every Release workflow shows red.
- Root cause: `undici@7.25.0` (pulled in transitively by `@octokit/request`) added stricter header-value validation and now rejects the numeric `content-length` header value on the binary asset upload. Pinning back to `7.24.8` (already elsewhere in the graph) via a pnpm `overrides` entry fixes it without touching any first-party code.

## Test plan
- [x] `pnpm install` — confirms only `undici@7.24.8` remains in the lockfile
- [x] `pnpm fmt`, `pnpm lint:es` — clean
- [ ] Merge and watch the next `Release` run go green with an actual published (non-draft) GitHub release