### PR TITLE
fix(ci): pin release job to Node 22, correct #202's ineffective fix

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -1,13 +1,27 @@
 name: 'Setup CI'
 description: 'Check out code, setup pnpm, and setup Node.js'
 
+inputs:
+  node-version:
+    description: 'Override Node.js version (defaults to engines.node in package.json)'
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
 
-    - name: Setup Node.js
+    - name: Setup Node.js (pinned)
+      if: inputs.node-version != ''
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+
+    - name: Setup Node.js (from package.json)
+      if: inputs.node-version == ''
       uses: actions/setup-node@v6
       with:
         node-version-file: 'package.json'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,6 +59,12 @@ jobs:
 
       - name: Setup CI Environment
         uses: ./.github/actions/setup-ci
+        with:
+          # Node 24.18.0's bundled undici rejects the numeric content-length
+          # header @octokit/request sends on the release asset upload,
+          # failing every Release run. semantic-release supports
+          # ^22.14.0 || >=24.10.0 — pin this job to 22 until upstream fixes it.
+          node-version: '22'
 
       - name: Semantic Release
         env:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ catalogs:
       specifier: ^4.3.6
       version: 4.3.6
 
-overrides:
-  '@semantic-release/github>undici': 7.24.8
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,5 @@
 packages:
   - '.'
-overrides:
-  # @semantic-release/github pulls undici@7.25.0, which throws "invalid
-  # content-length header" during the release asset upload, failing every
-  # Release run. Scoped to that one edge so @actions/http-client keeps its
-  # own undici@6 line untouched.
-  '@semantic-release/github>undici': 7.24.8
 catalog:
   '@internationalized/date': ^3.12.1
   '@sveltejs/kit': ^2.57.1


### PR DESCRIPTION
## Summary
- #202 pinned the npm `undici` package to `7.24.8`, but that didn't fix anything: after merge, the very next Release run (v4.11.1) failed with the identical `invalid content-length header` error — this time thrown from `undici@7.24.8` itself.
- The real throw site is `node:internal/deps/undici` — **Node's own bundled fetch/undici**, not the npm `undici` package at all. Pinning the npm dependency graph can never touch that.
- Root cause: comparing the last green Release run (v4.7.0, 2026-06-24) against the first failing one (v4.8.0, 2026-06-27), the resolved `pnpm-lock.yaml` is byte-identical — but the GitHub-hosted runner's Node version moved from `24.16.0` to `24.18.0` in between. `24.18.0`'s bundled undici started rejecting the numeric `content-length` header `@octokit/request` sends during `@semantic-release/github`'s release asset upload.
- `semantic-release`'s own `engines.node` is `^22.14.0 || >=24.10.0`, so Node 22 is a supported, safe target — and it predates this regression.

## Changes
- Drop the now-confirmed-ineffective `'@semantic-release/github>undici'` override from `pnpm-workspace.yaml`.
- Add an optional `node-version` input to `.github/actions/setup-ci` (defaults to the existing `engines.node`-file behavior).
- Pin just the `version-and-publish` job in `cd.yaml` to `node-version: '22'`. Build/test jobs keep floating on `engines.node`'s `^24.0.0` — untouched.

## Test plan
- [x] `pnpm install`, `pnpm fmt`, `pnpm lint:es` — clean
- [ ] Merge and watch the next `Release` run go green with an actual published (non-draft) GitHub release