### PR TITLE
fix(ci): bypass engineStrict for the pinned-Node-22 Release job

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -29,4 +29,6 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      # engineStrict rejects a pinned node-version override that doesn't match
+      # engines.node in package.json (e.g. the Release job's Node 22 vs ^24.0.0).
+      run: pnpm install --frozen-lockfile ${{ inputs.node-version != '' && '--config.engine-strict=false' || '' }}


### PR DESCRIPTION
## Summary
- #203 pinned the Release job's Node to 22, but the merge's next Release run (v4.11.2) failed immediately at `pnpm install --frozen-lockfile`:
  ```
  [ERR_PNPM_UNSUPPORTED_ENGINE] Unsupported environment
  Expected version: ^24.0.0
  Got: v22.23.1
  ```
- `pnpm-workspace.yaml` has `engineStrict: true` and `package.json` declares `engines.node: ^24.0.0` — Node 22 satisfies `semantic-release`'s own range but not this repo's. `--frozen-lockfile` doesn't bypass engine checks on its own.
- Reproduced locally (temporarily set `engines.node` to a version my Node doesn't satisfy) and confirmed `pnpm install --config.engine-strict=false` is what actually gets past it — a plain retry or different flag wouldn't have.

## Change
`setup-ci`'s install step now appends `--config.engine-strict=false` **only when `node-version` is explicitly overridden** (i.e. only the Release job). Build/test jobs keep enforcing `^24.0.0` untouched.

## Test plan
- [x] Reproduced the exact failure locally and confirmed the flag fixes it
- [x] `pnpm fmt` — clean
- [ ] Merge and watch the next `Release` run go green with an actual published (non-draft) GitHub release