### PR TITLE
fix(ci): bypass engineStrict via job env var, not a CLI flag

### DIFF
--- a/.github/actions/setup-ci/action.yaml
+++ b/.github/actions/setup-ci/action.yaml
@@ -29,6 +29,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      # engineStrict rejects a pinned node-version override that doesn't match
-      # engines.node in package.json (e.g. the Release job's Node 22 vs ^24.0.0).
-      run: pnpm install --frozen-lockfile ${{ inputs.node-version != '' && '--config.engine-strict=false' || '' }}
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -51,6 +51,17 @@ jobs:
       pull-requests: write
       id-token: write
 
+    env:
+      # Node 24.18.0's bundled undici rejects the numeric content-length
+      # header @octokit/request sends on the release asset upload, failing
+      # every Release run. semantic-release supports ^22.14.0 || >=24.10.0,
+      # so this job pins Node to 22 until upstream fixes it — which trips
+      # engineStrict (package.json wants ^24.0.0) on every pnpm invocation
+      # this job makes, including the `pnpm pack` @anolilab/semantic-release-pnpm
+      # runs internally. Only an env var reaches that subprocess; a CLI flag
+      # on our own `pnpm install` step does not.
+      PNPM_CONFIG_ENGINE_STRICT: 'false'
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -60,10 +71,6 @@ jobs:
       - name: Setup CI Environment
         uses: ./.github/actions/setup-ci
         with:
-          # Node 24.18.0's bundled undici rejects the numeric content-length
-          # header @octokit/request sends on the release asset upload,
-          # failing every Release run. semantic-release supports
-          # ^22.14.0 || >=24.10.0 — pin this job to 22 until upstream fixes it.
           node-version: '22'
 
       - name: Semantic Release


### PR DESCRIPTION
## Summary
- #204's `--config.engine-strict=false` only reached our own `pnpm install` step. `@anolilab/semantic-release-pnpm`'s publish step shells out to its own internal `pnpm pack` subprocess — CLI flags on our step don't propagate to that — so it hit `engineStrict` fresh and the very next Release run (v4.11.2) failed at that exact point.
- Fix: `PNPM_CONFIG_ENGINE_STRICT: 'false'` as a **job-level env var** on `version-and-publish`. Env vars propagate to every subprocess the job spawns, unlike a CLI flag scoped to one step.
- This time verified all three pnpm call sites this job actually makes — `install`, `pack` (what semantic-release-pnpm runs), and `publish --dry-run` (what actually ships to npm) — locally, against a deliberately Node-version-mismatched `engines.node`, before pushing.

## Test plan
- [x] Reproduced the exact `pnpm pack` failure locally, confirmed the env var (not a CLI flag) fixes it
- [x] Verified `install`, `pack`, and `publish --dry-run` all succeed under the env var
- [x] `pnpm fmt`, `pnpm lint:es` — clean
- [ ] Merge and watch the next `Release` run go green end-to-end (not just build checks) with a real published GitHub release