### PR TITLE
feat(form): add size and icon props to Button

### DIFF
--- a/src/lib/shared/components/form/Button.svelte
+++ b/src/lib/shared/components/form/Button.svelte
@@ -6,6 +6,7 @@
   import Loader2 from '@lucide/svelte/icons/loader-2';
   import { Button as ButtonPrimitive } from 'bits-ui';
 
+  type Size = 'small' | (string & {});
   type Variant = 'default' | 'destructive' | 'ghost' | 'ghost-destructive' | (string & {});
 
   interface Props extends Omit<HTMLButtonAttributes, 'form' | 'type'> {
@@ -13,9 +14,13 @@
     class?: string;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     href?: string;
+    /** Square, zero-padding footprint for a single icon child. Combines with `size`. */
+    icon?: boolean;
     loading?: boolean;
     loadingMessage?: string;
     reset?: boolean;
+    /** Omit for the default 40px-tall button. */
+    size?: Size;
     variant?: Variant;
   }
 
@@ -25,28 +30,26 @@
     disabled,
     form,
     href,
+    icon = false,
     loading = false,
     loadingMessage,
     reset = false,
+    size,
     variant = 'default',
     ...restProps
   }: Props = $props();
 
   const isPending = $derived(form ? form.pending > 0 : loading);
   const type = $derived(reset ? 'reset' : form ? 'submit' : 'button');
+  const classes = $derived(`btn ${variant} ${size ?? ''} ${icon ? 'icon' : ''} ${className}`);
 </script>
 
 {#if href}
-  <ButtonPrimitive.Root class="btn {variant} {className}" {href}>
+  <ButtonPrimitive.Root class={classes} {href}>
     {@render children?.()}
   </ButtonPrimitive.Root>
 {:else}
-  <ButtonPrimitive.Root
-    class="btn {variant} {className}"
-    disabled={disabled || isPending}
-    {type}
-    {...restProps}
-  >
+  <ButtonPrimitive.Root class={classes} disabled={disabled || isPending} {type} {...restProps}>
     {#if isPending}
       <Loader2 class="animate-spin" size={14} />
       {#if loadingMessage}{loadingMessage}{/if}


### PR DESCRIPTION
## Summary
- `size="small"` prop on `Button` — appends a `small` class token for a shorter footprint. Omitted = today's default 40px height, fully backward compatible.
- `icon` prop — square, zero-padding footprint for a single-icon child. Combines with `size` (`icon size="small"` = 28x28, `icon` alone = 40x40).
- Both are additive class tokens on the existing `class="btn {variant} ..."` template — this package intentionally ships no new CSS for `.btn.small`/`.btn.icon`; visual rules stay owned by whatever consuming app's stylesheet defines `.btn` (glasa's `@glasa/ui/template.css` in our case).

## Why
Driven by a refactor in the glasa monorepo to stop hand-styling one-off `<button>` elements and consolidate onto the shared `Button` component — several call sites just needed a shorter button or an icon-only button, which `Button` couldn't express before this.

## Test plan
- [x] `pnpm lint:es` / `pnpm lint:svelte` — 0 errors
- [x] `pnpm test:unit` — 171/171 passing
- [x] `pnpm build:lib` (svelte-package + publint) — passes