### PR TITLE
fix(form): disabled passthrough on Field family, full attrs on MessageField

### DIFF
--- a/src/lib/shared/components/form/Field.svelte
+++ b/src/lib/shared/components/form/Field.svelte
@@ -17,6 +17,8 @@
     children?: Snippet;
     /** Extra class(es) merged onto the underlying <input> (in addition to `form-input`). */
     class?: string;
+    /** Passed through to the underlying <input>. */
+    disabled?: HTMLInputAttributes['disabled'];
     /** When omitted the field is standalone — controlled via `bind:value`. */
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
@@ -45,6 +47,7 @@
     autocomplete,
     children,
     class: className,
+    disabled,
     form,
     icon,
     inputmode,
@@ -93,6 +96,7 @@
     class={className}
     {autocapitalize}
     {autocomplete}
+    {disabled}
     {icon}
     {inputmode}
     {onkeydown}

--- a/src/lib/shared/components/form/fields/EmailField.svelte
+++ b/src/lib/shared/components/form/fields/EmailField.svelte
@@ -11,6 +11,7 @@
     autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
     class?: string;
+    disabled?: HTMLInputAttributes['disabled'];
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     name: keyof Input & string;
     onChange?: (value: T) => void;
@@ -28,6 +29,7 @@
     autocomplete,
     children,
     class: className,
+    disabled,
     form,
     name,
     onChange,
@@ -47,6 +49,7 @@
   {autocapitalize}
   {autocomplete}
   {children}
+  {disabled}
   {form}
   {onChange}
   {onInput}

--- a/src/lib/shared/components/form/fields/MessageField.svelte
+++ b/src/lib/shared/components/form/fields/MessageField.svelte
@@ -1,6 +1,7 @@
 <script generics="Input extends RemoteFormInput, T = string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
+  import type { HTMLTextareaAttributes } from 'svelte/elements';
   import type { ZodType } from 'zod/v4';
 
   import TextArea from '$lib/shared/components/ui/TextArea.svelte';
@@ -9,34 +10,46 @@
   import FieldLabel from '../FieldLabel.svelte';
 
   interface Props {
+    /** Native autocomplete hint — passed through to the underlying <textarea>. */
+    autocomplete?: HTMLTextareaAttributes['autocomplete'];
     children?: Snippet;
     class?: string;
     defaultHeight?: number;
+    /** Passed through to the underlying <textarea>. */
+    disabled?: HTMLTextareaAttributes['disabled'];
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     name: keyof Input & string;
     onChange?: (value: T) => void;
     onInput?: (value: T) => void;
+    /** Raw native keydown — passed through to the underlying <textarea> (e.g. Enter-to-submit). */
+    onkeydown?: HTMLTextareaAttributes['onkeydown'];
     optional?: boolean;
     placeholder?: string;
     resize?: boolean;
     schema?: ZodType;
+    /** Native spellcheck hint — passed through to the underlying <textarea>. */
+    spellcheck?: HTMLTextareaAttributes['spellcheck'];
     value?: T;
   }
 
   let {
+    autocomplete,
     children,
     class: className,
     defaultHeight = 100,
+    disabled,
     form,
     icon,
     name,
     onChange,
     onInput,
+    onkeydown,
     optional,
     placeholder,
     resize = false,
     schema,
+    spellcheck,
     value = $bindable()
   }: Props = $props();
 
@@ -70,11 +83,15 @@
   <TextArea
     id={view.attrs.name}
     class={className}
+    {autocomplete}
     {defaultHeight}
+    {disabled}
     {icon}
+    {onkeydown}
     placeholder={displayPlaceholder}
     {required}
     {resize}
+    {spellcheck}
     {...view.attrs}
   />
   {#each view.issues() as issue (`${issue.path}`)}

--- a/src/lib/shared/components/form/fields/NumberField.svelte
+++ b/src/lib/shared/components/form/fields/NumberField.svelte
@@ -10,6 +10,7 @@
     autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
     class?: string;
+    disabled?: HTMLInputAttributes['disabled'];
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     /** Mobile keyboard hint — e.g. 'numeric' to avoid the native spinner while keeping the numeric pad. */
@@ -28,6 +29,7 @@
     autocomplete,
     children,
     class: className,
+    disabled,
     form,
     icon,
     inputmode,
@@ -47,6 +49,7 @@
   class={className}
   {autocomplete}
   {children}
+  {disabled}
   {form}
   {icon}
   {inputmode}

--- a/src/lib/shared/components/form/fields/TextField.svelte
+++ b/src/lib/shared/components/form/fields/TextField.svelte
@@ -11,6 +11,7 @@
     autocomplete?: HTMLInputAttributes['autocomplete'];
     children?: Snippet;
     class?: string;
+    disabled?: HTMLInputAttributes['disabled'];
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
     icon?: Component;
     inputmode?: HTMLInputAttributes['inputmode'];
@@ -32,6 +33,7 @@
     autocomplete,
     children,
     class: className,
+    disabled,
     form,
     icon,
     inputmode,
@@ -54,6 +56,7 @@
   {autocapitalize}
   {autocomplete}
   {children}
+  {disabled}
   {form}
   {icon}
   {inputmode}


### PR DESCRIPTION
## Summary
- Adds `disabled` passthrough to `Field.svelte`, `TextField`, `EmailField`, `NumberField` — they already forward `onkeydown`/`autocomplete`/`inputmode`/`spellcheck` (#201) but were missing `disabled`.
- `MessageField` had zero attribute passthrough despite `TextArea` already supporting it via `...rest`. Brought it to parity with `TextField`'s surface: `autocomplete`/`disabled`/`onkeydown`/`spellcheck`.

Unblocks call sites that need both a disabled/pending state (or a keydown handler) and schema-validated inline field errors — e.g. a submit-in-progress form field — without dropping down to the standalone `Input`/`TextArea` (which have no `schema` support).

## Test plan
- [x] `pnpm lint:es`
- [x] `pnpm lint:svelte` (0 errors/warnings)
- [x] `pnpm test` (171 tests passing)
- [x] `pnpm fmt` (no diff)