### PR TITLE
feat(form): add controlled open/onOpenChange to Combobox

### DIFF
--- a/src/lib/shared/components/form/fields/Combobox.svelte
+++ b/src/lib/shared/components/form/fields/Combobox.svelte
@@ -30,6 +30,8 @@
     name: keyof Input & string;
     /** Only meaningful for single-select — ignored when `multiple`. */
     nullable?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
     optional?: boolean;
     placeholder: string;
     schema?: ZodType;
@@ -63,6 +65,8 @@
     name,
     nullable = false,
     onchange,
+    onOpenChange,
+    open = $bindable(false),
     optional,
     placeholder,
     schema,
@@ -170,10 +174,12 @@
   {#if multiple}
     <ComboboxPrimitive.Root
       items={bitsItems}
+      {onOpenChange}
       onValueChange={(keys) => handleMultiChange(keys)}
       {required}
       type="multiple"
       value={selectedKeys}
+      bind:open
     >
       <div
         class={['form-input', 'form-select', 'form-combobox', 'form-combobox-multi', className]
@@ -241,10 +247,12 @@
       allowDeselect={nullable}
       inputValue={selectedLabel ?? ''}
       items={bitsItems}
+      {onOpenChange}
       onValueChange={(key) => handleSingleChange(key)}
       {required}
       type="single"
       value={selectedKey}
+      bind:open
     >
       <div
         class={['form-input', 'form-select', 'form-combobox', className].filter(Boolean).join(' ')}


### PR DESCRIPTION
## Summary
`Combobox` had no way to close its popover from outside — e.g. before opening a `Dialog` from a footer action, where the still-open popover (portaled, higher z-index than a dialog backdrop by design) would render above the dialog that just opened. Adds a bindable `open` + `onOpenChange`, same pattern as the existing `value` prop.

## Test plan
- [x] `svelte-check` — 0 errors/warnings
- [x] `eslint` — clean
- [x] `vitest` — 171/171 passing
- [x] `pnpm build:lib` — passes
- [x] Exercised in a real dashboard component (account switcher `bind:open` closes the popover before its "create account" dialog opens)