### PR TITLE
fix(form): add missing SliderField export to fields barrel

### DIFF
--- a/src/lib/shared/components/form/fields/index.ts
+++ b/src/lib/shared/components/form/fields/index.ts
@@ -11,6 +11,7 @@ export { default as Option } from './Option.svelte';
 export { default as PasswordField } from './PasswordField.svelte';
 export { default as PinField } from './PinField.svelte';
 export { default as SelectField } from './SelectField.svelte';
+export { default as SliderField } from './SliderField.svelte';
 export { default as SwitchField } from './SwitchField.svelte';
 export { default as TextField } from './TextField.svelte';
 export { default as TimeField } from './TimeField.svelte';


### PR DESCRIPTION
## Summary
`SliderField.svelte` existed (added in #189) and was correctly exported from the top-level `components/form` barrel, but never got added to `components/form/fields`'s barrel — every other field has an entry there, this one was just missed.

Caught while migrating `apps/marketing`'s Pricing page off a hand-rolled `<input type="range">` — importing `SliderField` from `.../components/form/fields` failed with "no exported member" even though the file itself is fine.

## Test plan
- [x] `pnpm lint:es`
- [x] `pnpm lint:svelte` (0 errors/warnings)
- [x] `pnpm test` (171 tests passing)
- [x] `pnpm fmt` (no diff beyond the one line)