### PR TITLE
feat(form)!: rework Combobox to declarative Option children

### DIFF
--- a/src/lib/shared/components/form/fields/Combobox.svelte
+++ b/src/lib/shared/components/form/fields/Combobox.svelte
@@ -1,32 +1,37 @@
-<script generics="Input extends RemoteFormInput, I, V, K extends number | string" lang="ts">
+<script generics="Input extends RemoteFormInput, V extends number | string" lang="ts">
   import type { RemoteForm, RemoteFormInput } from '@sveltejs/kit';
   import type { Component, Snippet } from 'svelte';
   import type { ZodType } from 'zod/v4';
 
-  import Check from '@lucide/svelte/icons/check';
   import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
   import X from '@lucide/svelte/icons/x';
   import { Combobox as ComboboxPrimitive } from 'bits-ui';
+  import { setContext } from 'svelte';
+  import { SvelteMap } from 'svelte/reactivity';
 
-  import { fuzzySearch, fuzzySearchHighlight } from '../../../utils/string.js';
+  import { fuzzySearch } from '../../../utils/string.js';
   import { createFormView, createLocalSelectView, type FieldView } from '../field-view.svelte.js';
   import FieldLabel from '../FieldLabel.svelte';
+  import {
+    SELECT_FIELD_CONTEXT,
+    type SelectFieldContext,
+    type SelectFieldEntry
+  } from './select-field-context.js';
 
-  type BaseProps<Input extends RemoteFormInput, I, V, K extends number | string> = {
-    children?: Snippet;
+  type BaseProps<Input extends RemoteFormInput> = {
+    /** The `<Option>` list — declarative, native `<select><option>`-style. */
+    children: Snippet;
     class?: string;
     /** Overrides the "no results" row. Receives the current search query. */
     empty?: Snippet<[query: string]>;
     /** Rendered below the option list, inside the panel (e.g. an "add new…" action). */
     footer?: Snippet;
     form?: Omit<RemoteForm<Input, unknown>, 'for'> | RemoteForm<Input, unknown>;
-    getKey: (item: I) => K;
-    getLabel: (item: I) => string;
-    getValue: (item: I) => V;
     /** Rendered above the option list, inside the panel (e.g. a hint line). */
     header?: Snippet;
     icon?: Component;
-    items: readonly I[];
+    /** Field label text. Not `children` here — that's the option list. */
+    label?: string;
     name: keyof Input & string;
     /** Only meaningful for single-select — ignored when `multiple`. */
     nullable?: boolean;
@@ -37,13 +42,13 @@
     schema?: ZodType;
   };
 
-  type Props<Input extends RemoteFormInput, I, V, K extends number | string> =
-    | (BaseProps<Input, I, V, K> & {
+  type Props<Input extends RemoteFormInput, V> =
+    | (BaseProps<Input> & {
         multiple: true;
         onchange?: (value: V[]) => void;
         value?: V[];
       })
-    | (BaseProps<Input, I, V, K> & {
+    | (BaseProps<Input> & {
         multiple?: false;
         onchange?: (value: undefined | V) => void;
         value?: undefined | V;
@@ -55,12 +60,9 @@
     empty,
     footer,
     form,
-    getKey,
-    getLabel,
-    getValue,
     header,
     icon: Icon,
-    items,
+    label,
     multiple = false,
     name,
     nullable = false,
@@ -71,7 +73,18 @@
     placeholder,
     schema,
     value = $bindable()
-  }: Props<Input, I, V, K> = $props();
+  }: Props<Input, V> = $props();
+
+  const registry = new SvelteMap<string, SelectFieldEntry>();
+  let query = $state('');
+  const context: SelectFieldContext = {
+    getQuery: () => query,
+    register: (key, entry) => registry.set(key, entry),
+    unregister: (key) => registry.delete(key)
+  };
+  setContext(SELECT_FIELD_CONTEXT, context);
+
+  let boxEl = $state<HTMLDivElement | undefined>();
 
   // `as('select'|'select multiple')` is reached only via the `form` branch — SvelteKit's remote
   // forms natively support both (RemoteFormFieldType resolves 'select multiple' for a string[]
@@ -89,61 +102,48 @@
   const attrs = $derived(view.attrs);
   const required = $derived(!optional);
   const displayPlaceholder = $derived(
-    children || required || !placeholder ? placeholder : `${placeholder} (Optional)`
-  );
-
-  let query = $state('');
-
-  const keyToValue = $derived(
-    new Map(items.map((item) => [String(getKey(item)), String(getValue(item))]))
-  );
-  const valueToItem = $derived(new Map(items.map((item) => [String(getValue(item)), item])));
-  const valueToKey = $derived(
-    new Map(items.map((item) => [String(getValue(item)), String(getKey(item))]))
-  );
-  const keyToLabel = $derived(new Map(items.map((item) => [String(getKey(item)), getLabel(item)])));
-
-  const filteredItems = $derived(
-    query.trim() === '' ? items : items.filter((item) => fuzzySearch(query, getLabel(item)))
+    label || required || !placeholder ? placeholder : `${placeholder} (Optional)`
   );
 
   // bits-ui `Combobox` uses this {value,label} list for typeahead matching, same as `Select`.
   const bitsItems = $derived(
-    items.map((item) => ({ label: getLabel(item), value: String(getKey(item)) }))
+    [...registry.entries()].map(([key, entry]) => ({ label: entry.label, value: key }))
   );
 
-  // Form mode stores the submitted key(s); standalone tracks the typed value(s), resolved to
-  // key(s) via valueToKey — same split SelectField uses, just branched on `multiple`.
+  const hasVisibleOptions = $derived(
+    [...registry.values()].some((entry) => query.trim() === '' || fuzzySearch(query, entry.label))
+  );
+
+  // Form mode stores the submitted key(s); standalone tracks the typed value(s), keyed the same
+  // way `<Option>` derives its own key (`String(value)`) — same split `SelectField` uses, just
+  // branched on `multiple`.
   const selectedKey = $derived(
-    !multiple ? (form ? (attrs.value as string) : (valueToKey.get(String(value ?? '')) ?? '')) : ''
+    !multiple ? (form ? (attrs.value as string) : String(value ?? '')) : ''
   );
   const selectedKeys = $derived(
     multiple
       ? form
         ? ((attrs.value as string[] | undefined) ?? [])
-        : ((value as undefined | V[]) ?? []).map((v) => valueToKey.get(String(v)) ?? '')
+        : ((value as undefined | V[]) ?? []).map((v) => String(v))
       : []
   );
-  const selectedLabel = $derived(keyToLabel.get(selectedKey));
+  const selectedLabel = $derived(registry.get(selectedKey)?.label);
   const selectedChips = $derived(
     selectedKeys
-      .map((key) => ({ key, label: keyToLabel.get(key) ?? key }))
+      .map((key) => ({ key, label: registry.get(key)?.label ?? key }))
       .filter((chip) => chip.label)
   );
 
   function handleSingleChange(key: string) {
-    const newValue = keyToValue.get(key) ?? '';
-    const item = valueToItem.get(newValue);
-    const typedValue = item === undefined ? undefined : getValue(item);
+    const typedValue = registry.get(key)?.value as undefined | V;
     view.set(typedValue);
     (onchange as ((value: undefined | V) => void) | undefined)?.(typedValue);
   }
 
   function handleMultiChange(keys: string[]) {
     const typedValues = keys
-      .map((key) => valueToItem.get(keyToValue.get(key) ?? ''))
-      .filter((item): item is I => item !== undefined)
-      .map((item) => getValue(item));
+      .map((key) => registry.get(key)?.value)
+      .filter((v): v is V => v !== undefined);
     view.set(typedValues);
     (onchange as ((value: V[]) => void) | undefined)?.(typedValues);
   }
@@ -153,22 +153,9 @@
   }
 </script>
 
-{#snippet optionRow(item: I)}
-  {@const label = getLabel(item)}
-  {@const highlighted = query.trim() === '' ? null : fuzzySearchHighlight(query, label)}
-  <span class="form-select-item-label">
-    {#if highlighted}
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-      {@html highlighted}
-    {:else}
-      {label}
-    {/if}
-  </span>
-{/snippet}
-
 <div class="form-field">
-  {#if children}
-    <FieldLabel for={attrs.name} {required}>{@render children()}</FieldLabel>
+  {#if label}
+    <FieldLabel for={attrs.name} {required}>{label}</FieldLabel>
   {/if}
 
   {#if multiple}
@@ -182,6 +169,7 @@
       bind:open
     >
       <div
+        bind:this={boxEl}
         class={['form-input', 'form-select', 'form-combobox', 'form-combobox-multi', className]
           .filter(Boolean)
           .join(' ')}
@@ -212,22 +200,16 @@
         </ComboboxPrimitive.Trigger>
       </div>
       <ComboboxPrimitive.Portal>
-        <ComboboxPrimitive.Content class="form-select-menu form-combobox-menu" sideOffset={4}>
+        <ComboboxPrimitive.Content
+          class="form-select-menu form-combobox-menu"
+          customAnchor={boxEl}
+          forceMount
+          sideOffset={4}
+        >
           {#if header}<div class="form-combobox-header">{@render header()}</div>{/if}
           <ComboboxPrimitive.Viewport>
-            {#each filteredItems as item (getKey(item))}
-              <ComboboxPrimitive.Item
-                class="form-select-item"
-                label={getLabel(item)}
-                value={String(getKey(item))}
-              >
-                {#snippet children({ selected })}
-                  {@render optionRow(item)}
-                  {#if selected}<Check class="form-select-item-check" size={14} />{/if}
-                {/snippet}
-              </ComboboxPrimitive.Item>
-            {/each}
-            {#if filteredItems.length === 0}
+            {@render children()}
+            {#if !hasVisibleOptions}
               {#if empty}
                 {@render empty(query)}
               {:else}
@@ -240,7 +222,7 @@
       </ComboboxPrimitive.Portal>
     </ComboboxPrimitive.Root>
     {#each selectedKeys as key (key)}
-      <input name={attrs.name} type="hidden" value={keyToValue.get(key) ?? ''} />
+      <input name={attrs.name} type="hidden" value={key} />
     {/each}
   {:else}
     <ComboboxPrimitive.Root
@@ -255,6 +237,7 @@
       bind:open
     >
       <div
+        bind:this={boxEl}
         class={['form-input', 'form-select', 'form-combobox', className].filter(Boolean).join(' ')}
       >
         {#if Icon}<Icon class="form-input-icon" />{/if}
@@ -268,22 +251,16 @@
         </ComboboxPrimitive.Trigger>
       </div>
       <ComboboxPrimitive.Portal>
-        <ComboboxPrimitive.Content class="form-select-menu form-combobox-menu" sideOffset={4}>
+        <ComboboxPrimitive.Content
+          class="form-select-menu form-combobox-menu"
+          customAnchor={boxEl}
+          forceMount
+          sideOffset={4}
+        >
           {#if header}<div class="form-combobox-header">{@render header()}</div>{/if}
           <ComboboxPrimitive.Viewport>
-            {#each filteredItems as item (getKey(item))}
-              <ComboboxPrimitive.Item
-                class="form-select-item"
-                label={getLabel(item)}
-                value={String(getKey(item))}
-              >
-                {#snippet children({ selected })}
-                  {@render optionRow(item)}
-                  {#if selected}<Check class="form-select-item-check" size={14} />{/if}
-                {/snippet}
-              </ComboboxPrimitive.Item>
-            {/each}
-            {#if filteredItems.length === 0}
+            {@render children()}
+            {#if !hasVisibleOptions}
               {#if empty}
                 {@render empty(query)}
               {:else}

--- a/src/lib/shared/components/form/fields/ComboboxAction.svelte
+++ b/src/lib/shared/components/form/fields/ComboboxAction.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Component, Snippet } from 'svelte';
+
+  interface Props {
+    children: Snippet;
+    icon?: Component;
+    onclick: () => void;
+  }
+
+  let { children, icon: Icon, onclick }: Props = $props();
+</script>
+
+<button class="form-combobox-action" {onclick} type="button">
+  {#if Icon}<Icon size={13} />{/if}
+  {@render children()}
+</button>

--- a/src/lib/shared/components/form/fields/Option.svelte
+++ b/src/lib/shared/components/form/fields/Option.svelte
@@ -5,6 +5,7 @@
   import { Select } from 'bits-ui';
   import { getContext } from 'svelte';
 
+  import { fuzzySearch } from '../../../utils/string.js';
   import { SELECT_FIELD_CONTEXT, type SelectFieldContext } from './select-field-context.js';
 
   interface Props {
@@ -34,11 +35,16 @@
   $effect(() => {
     return () => ctx.unregister(key);
   });
+
+  const query = $derived(ctx.getQuery?.() ?? '');
+  const visible = $derived(query.trim() === '' || fuzzySearch(query, resolvedLabel));
 </script>
 
-<Select.Item class="form-select-item" label={resolvedLabel} value={key}>
-  {#snippet children({ selected })}
-    <span class="form-select-item-label">{@render content()}</span>
-    {#if selected}<Check class="form-select-item-check" size={14} />{/if}
-  {/snippet}
-</Select.Item>
+{#if visible}
+  <Select.Item class="form-select-item" label={resolvedLabel} value={key}>
+    {#snippet children({ selected })}
+      <span class="form-select-item-label">{@render content()}</span>
+      {#if selected}<Check class="form-select-item-check" size={14} />{/if}
+    {/snippet}
+  </Select.Item>
+{/if}

--- a/src/lib/shared/components/form/fields/SelectField.svelte
+++ b/src/lib/shared/components/form/fields/SelectField.svelte
@@ -118,7 +118,7 @@
       <ChevronDown class="form-select-chevron" size={14} />
     </Select.Trigger>
     <Select.Portal>
-      <Select.Content class="form-select-menu" sideOffset={4}>
+      <Select.Content class="form-select-menu" forceMount sideOffset={4}>
         <Select.Viewport>
           {@render children()}
         </Select.Viewport>

--- a/src/lib/shared/components/form/fields/index.ts
+++ b/src/lib/shared/components/form/fields/index.ts
@@ -1,5 +1,6 @@
 export { default as CheckboxField } from './CheckboxField.svelte';
 export { default as Combobox } from './Combobox.svelte';
+export { default as ComboboxAction } from './ComboboxAction.svelte';
 export { default as DateField } from './DateField.svelte';
 export { default as DateRangeField } from './DateRangeField.svelte';
 export { default as EmailField } from './EmailField.svelte';

--- a/src/lib/shared/components/form/fields/select-field-context.ts
+++ b/src/lib/shared/components/form/fields/select-field-context.ts
@@ -12,6 +12,8 @@ export type SelectFieldEntry = {
 };
 
 export type SelectFieldContext = {
+  /** Live search query, only set by `<Combobox>` — `<Option>` filters itself against it. */
+  getQuery?: () => string;
   register: (key: string, entry: SelectFieldEntry) => void;
   unregister: (key: string) => void;
 };

--- a/src/lib/shared/components/form/index.ts
+++ b/src/lib/shared/components/form/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './Button.svelte';
 export { default as CheckboxField } from './fields/CheckboxField.svelte';
 export { default as Combobox } from './fields/Combobox.svelte';
+export { default as ComboboxAction } from './fields/ComboboxAction.svelte';
 export { default as DateField } from './fields/DateField.svelte';
 export { default as DateRangeField } from './fields/DateRangeField.svelte';
 export { default as EmailField } from './fields/EmailField.svelte';


### PR DESCRIPTION
## Summary
- **Breaking:** `Combobox` drops its `items`/`getKey`/`getLabel`/`getValue` array API for the same declarative `<Option>` children `SelectField` already uses — one consistent shape across both instead of two. Search filters by each `<Option>` self-checking a live query read from context.
- Fixes the popover width/position bug: it was anchored to the inner `<Input>` element (narrower than the field, worst on multi-select where the input is just the trailing sliver after the chips). Now uses bits-ui's `customAnchor`, pointed at the actual outer field box.
- Fixes a latent bug in already-shipped `SelectField`: `<Option>`s only mounted while the panel was open, so the registry entry backing the closed-trigger's label/content vanished the moment it closed. Both components now `forceMount` their panel.
- New `ComboboxAction` — the canonical footer/header action-row button (icon + label), so consumers don't hand-roll a `<button>` each time.

## Migration
```svelte
<!-- before -->
<Combobox items={list} getKey={(o) => o.id} getLabel={(o) => o.name} getValue={(o) => o.id} placeholder="..." bind:value />

<!-- after -->
<Combobox placeholder="..." bind:value>
  {#each list as item (item.id)}
    <Option value={item.id}>{item.name}</Option>
  {/each}
</Combobox>
```

## Test plan
- [x] `svelte-check` — 0 errors/warnings
- [x] `eslint` — clean
- [x] `vitest` — 171/171 passing
- [x] `pnpm build:lib` — passes
- [x] Migrated and exercised in a real dashboard component (account switcher) plus 3 showcase pages against this branch, including a production `pnpm build` of the consuming app